### PR TITLE
feat(website): add static multilingual HTML pages (Chinese base) and language redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Common Node/Vite artifacts
+node_modules/
+dist/
+build/
+.tmp/
+.temp/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Environment files
+.env
+.env.*
+
+# Editor directories and files
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Coverage / test output
+coverage/
+.junit/
+
+# Misc
+*.local

--- a/website/README-HTML.md
+++ b/website/README-HTML.md
@@ -1,0 +1,183 @@
+# 静态HTML多语言版本 / Static HTML Multilingual Version
+
+## 📁 文件说明 / File Description
+
+本目录包含完全独立的多语言静态HTML页面，无需Node.js环境即可直接在浏览器中打开使用。
+
+This directory contains fully standalone multilingual static HTML pages that can be opened directly in a browser without requiring a Node.js environment.
+
+### 文件列表 / File List
+
+- **index.html** - 自动语言检测入口页面 / Auto language detection entry page
+- **index.zh-CN.html** - 中文版本（底本）/ Chinese version (base)
+- **index.en.html** - 英文版本 / English version
+- **index.ru.html** - 俄语版本 / Russian version
+- **index.fr.html** - 法语版本 / French version
+
+## 🌟 特性 / Features
+
+### ✅ 完全自包含 / Fully Self-Contained
+- 所有样式直接内嵌在HTML中
+- 无需外部CSS/JS文件
+- 无需构建工具或服务器
+- 可直接用浏览器打开
+
+All styles are embedded directly in the HTML
+No external CSS/JS files required
+No build tools or server needed
+Can be opened directly with a browser
+
+### 🌍 多语言支持 / Multilingual Support
+- 🇨🇳 中文 (Chinese) - 底本版本
+- 🇬🇧 English - Based on Chinese content
+- 🇷🇺 Русский (Russian) - Based on Chinese content
+- 🇫🇷 Français (French) - Based on Chinese content
+
+### 📊 完整数据 / Complete Data
+- 60+ API提供商信息
+- 8个推荐应用
+- 标签图例说明
+- 使用指南
+- 贡献指南
+
+60+ API providers information
+8 recommended applications
+Tag legend explanations
+Usage guide
+Contribution guide
+
+### 🎨 现代设计 / Modern Design
+- 渐变背景色
+- 毛玻璃效果
+- 响应式布局
+- 移动端适配
+- 悬停动画效果
+
+Gradient backgrounds
+Glassmorphism effects
+Responsive layout
+Mobile-friendly
+Hover animations
+
+## 🚀 使用方法 / Usage
+
+### 方法1：直接打开 / Method 1: Direct Opening
+
+```bash
+# 在浏览器中打开任意HTML文件
+# Open any HTML file in a browser
+
+# Windows
+start index.html
+
+# Mac
+open index.html
+
+# Linux
+xdg-open index.html
+```
+
+### 方法2：本地服务器 / Method 2: Local Server
+
+```bash
+# Python 3
+python3 -m http.server 8000
+
+# Python 2
+python -m SimpleHTTPServer 8000
+
+# Node.js (如果已安装 / if installed)
+npx http-server -p 8000
+
+# 然后访问 / Then visit
+# http://localhost:8000
+```
+
+### 方法3：在线部署 / Method 3: Online Deployment
+
+可以直接将HTML文件部署到以下平台：
+You can directly deploy HTML files to the following platforms:
+
+- **GitHub Pages**
+- **Netlify**
+- **Vercel**
+- **Cloudflare Pages**
+- **GitLab Pages**
+- 任何支持静态文件的主机 / Any static file hosting
+
+## 🔄 与React版本的关系 / Relationship with React Version
+
+### React版本 (client/) / React Version
+- 需要Node.js环境和构建
+- 支持更复杂的交互功能
+- 使用TanStack Query进行数据获取
+- 支持客户端路由
+- 适合开发和扩展功能
+
+Requires Node.js environment and build
+Supports more complex interactive features
+Uses TanStack Query for data fetching
+Supports client-side routing
+Suitable for development and extending features
+
+### HTML版本 (当前目录) / HTML Version (Current Directory)
+- 纯静态文件，无需构建
+- 完全自包含，易于部署
+- 可直接分享和使用
+- 适合快速查看和分享
+- 适合无法运行Node.js的环境
+
+Pure static files, no build required
+Fully self-contained, easy to deploy
+Can be directly shared and used
+Suitable for quick viewing and sharing
+Suitable for environments without Node.js
+
+## 📝 内容更新 / Content Updates
+
+如需更新内容，请遵循以下步骤：
+To update content, follow these steps:
+
+1. **更新中文版本（底本）**：编辑 `index.zh-CN.html`
+   Update Chinese version (base): Edit `index.zh-CN.html`
+
+2. **同步到其他语言**：根据中文版本更新其他语言文件
+   Sync to other languages: Update other language files based on Chinese version
+
+3. **保持一致性**：确保所有语言版本的数据条目数量一致
+   Maintain consistency: Ensure all language versions have the same number of data entries
+
+## 🎯 浏览器兼容性 / Browser Compatibility
+
+支持所有现代浏览器：
+Supports all modern browsers:
+
+- ✅ Chrome/Edge 90+
+- ✅ Firefox 88+
+- ✅ Safari 14+
+- ✅ Opera 76+
+
+## 📱 移动端支持 / Mobile Support
+
+所有HTML页面都经过优化，支持移动设备：
+All HTML pages are optimized for mobile devices:
+
+- 响应式设计 / Responsive design
+- 触摸友好 / Touch-friendly
+- 性能优化 / Performance optimized
+- 小屏幕适配 / Small screen adapted
+
+## 🔗 相关链接 / Related Links
+
+- 项目主页 / Project Homepage: https://github.com/TechnologyStar/Openai-Claude-Deepseek-API-provider
+- 中文README / Chinese README: [../README.md](../README.md)
+- React版本 / React Version: [./client/](./client/)
+
+## 📄 许可证 / License
+
+与项目主仓库保持一致。
+Same as the main project repository.
+
+---
+
+**Made with ❤️ by TechnologyStar**

--- a/website/index.en.html
+++ b/website/index.en.html
@@ -1,0 +1,589 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>🌐 OpenAI / Claude / DeepSeek API Provider Directory</title>
+  <meta name="description" content="A curated list of third-party platforms providing OpenAI / Claude / DeepSeek APIs for learning, research, and non-commercial use.">
+  <meta name="keywords" content="OpenAI, Claude, DeepSeek, API, third-party, free, artificial intelligence, AI">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
+    }
+    
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    
+    header {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      margin-bottom: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+      text-align: center;
+    }
+    
+    h1 {
+      font-size: 2.5em;
+      margin-bottom: 15px;
+      color: #667eea;
+      text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    
+    .subtitle {
+      font-size: 1.2em;
+      color: #666;
+      margin-bottom: 20px;
+    }
+    
+    .badges {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin: 20px 0;
+    }
+    
+    .badges img {
+      height: 20px;
+    }
+    
+    .lang-switcher {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      margin-top: 20px;
+      flex-wrap: wrap;
+    }
+    
+    .lang-btn {
+      padding: 8px 16px;
+      background: #667eea;
+      color: white;
+      text-decoration: none;
+      border-radius: 20px;
+      font-size: 14px;
+      transition: all 0.3s;
+    }
+    
+    .lang-btn:hover {
+      background: #764ba2;
+      transform: translateY(-2px);
+      box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+    }
+    
+    .lang-btn.active {
+      background: #764ba2;
+    }
+    
+    .notice {
+      background: #fff3cd;
+      border-left: 4px solid #ffc107;
+      padding: 20px;
+      border-radius: 10px;
+      margin-bottom: 30px;
+    }
+    
+    .section {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      margin-bottom: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    }
+    
+    h2 {
+      font-size: 2em;
+      margin-bottom: 20px;
+      color: #667eea;
+      border-bottom: 3px solid #667eea;
+      padding-bottom: 10px;
+    }
+    
+    h3 {
+      font-size: 1.5em;
+      margin: 20px 0 10px;
+      color: #764ba2;
+    }
+    
+    .tags-legend {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 10px;
+      margin: 20px 0;
+    }
+    
+    .tag-item {
+      padding: 10px;
+      background: #f8f9fa;
+      border-radius: 8px;
+      border-left: 3px solid #667eea;
+    }
+    
+    .providers-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 20px 0;
+      overflow-x: auto;
+      display: block;
+    }
+    
+    .providers-table table {
+      width: 100%;
+      min-width: 800px;
+    }
+    
+    .providers-table th,
+    .providers-table td {
+      padding: 12px;
+      text-align: left;
+      border-bottom: 1px solid #e0e0e0;
+    }
+    
+    .providers-table th {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      font-weight: 600;
+      position: sticky;
+      top: 0;
+    }
+    
+    .providers-table tr:hover {
+      background: #f5f5f5;
+    }
+    
+    .providers-table a {
+      color: #667eea;
+      text-decoration: none;
+      font-weight: 500;
+    }
+    
+    .providers-table a:hover {
+      text-decoration: underline;
+    }
+    
+    .apps-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 20px;
+      margin: 20px 0;
+    }
+    
+    .app-card {
+      padding: 20px;
+      background: #f8f9fa;
+      border-radius: 10px;
+      border-left: 4px solid #667eea;
+      transition: all 0.3s;
+    }
+    
+    .app-card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+    }
+    
+    .app-card h4 {
+      color: #667eea;
+      margin-bottom: 10px;
+    }
+    
+    .usage-steps {
+      counter-reset: step;
+      list-style: none;
+      padding: 0;
+    }
+    
+    .usage-steps li {
+      counter-increment: step;
+      padding: 15px;
+      margin: 10px 0;
+      background: #f8f9fa;
+      border-radius: 10px;
+      position: relative;
+      padding-left: 60px;
+    }
+    
+    .usage-steps li::before {
+      content: counter(step);
+      position: absolute;
+      left: 15px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      width: 35px;
+      height: 35px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+    }
+    
+    footer {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      text-align: center;
+      margin-top: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    }
+    
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+      margin: 20px 0;
+    }
+    
+    .stat-card {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 25px;
+      border-radius: 10px;
+      text-align: center;
+    }
+    
+    .stat-number {
+      font-size: 3em;
+      font-weight: bold;
+      margin-bottom: 5px;
+    }
+    
+    .stat-label {
+      font-size: 1.1em;
+      opacity: 0.9;
+    }
+    
+    @media (max-width: 768px) {
+      h1 {
+        font-size: 1.8em;
+      }
+      
+      .providers-table {
+        font-size: 14px;
+      }
+      
+      .container {
+        padding: 10px;
+      }
+    }
+    
+    details {
+      margin: 20px 0;
+    }
+    
+    summary {
+      cursor: pointer;
+      padding: 15px;
+      background: #f8f9fa;
+      border-radius: 10px;
+      font-weight: 600;
+      color: #667eea;
+      user-select: none;
+    }
+    
+    summary:hover {
+      background: #e9ecef;
+    }
+    
+    details[open] summary {
+      margin-bottom: 15px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🌐 OpenAI / Claude / DeepSeek API Provider</h1>
+      <p class="subtitle">A curated list of third-party platforms providing</p>
+      <p class="subtitle">OpenAI / Claude / DeepSeek APIs for learning, research, and non-commercial use</p>
+      
+      <div class="badges">
+        <img src="https://img.shields.io/github/last-commit/TechnologyStar/Openai-Claude-Deepseek-API-provider" alt="Last Commit">
+        <img src="https://img.shields.io/github/license/TechnologyStar/Openai-Claude-Deepseek-API-provider" alt="License">
+      </div>
+      
+      <div class="lang-switcher">
+        <a href="index.zh-CN.html" class="lang-btn">🇨🇳 中文</a>
+        <a href="index.en.html" class="lang-btn active">🇬🇧 English</a>
+        <a href="index.ru.html" class="lang-btn">🇷🇺 Русский</a>
+        <a href="index.fr.html" class="lang-btn">🇫🇷 Français</a>
+      </div>
+    </header>
+    
+    <div class="notice section">
+      <h3>⚠️ Usage Notice</h3>
+      <p><strong>This is a free public service project. Any illegal use is strictly prohibited.</strong></p>
+      <ul style="margin-top: 10px; margin-left: 20px;">
+        <li>Follow <a href="https://openai.com/policies/terms-of-use" target="_blank">OpenAI Terms of Use</a></li>
+        <li>Respect local laws and regulations regarding generative AI services</li>
+      </ul>
+    </div>
+    
+    <div class="section">
+      <h2>🚀 Project Overview</h2>
+      <p>📌 A collection of verified third-party API providers (some offer free access)</p>
+      <p>🔧 No registration / Easy access / Multi-model support (OpenAI, Claude, DeepSeek, etc.)</p>
+      <p>🔐 Use caution: <strong>Do not enter sensitive personal data</strong> on any platform</p>
+      <p style="margin-top: 15px;">💡 If you find this helpful, consider giving it a Star! ⭐</p>
+    </div>
+    
+    <div class="section">
+      <h2>📊 Statistics</h2>
+      <div class="stats">
+        <div class="stat-card">
+          <div class="stat-number">60+</div>
+          <div class="stat-label">API Providers</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">20+</div>
+          <div class="stat-label">Free Platforms</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">8</div>
+          <div class="stat-label">Recommended Apps</div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="section">
+      <h2>🎁 Tag Legend</h2>
+      <div class="tags-legend">
+        <div class="tag-item">🆓 Completely Free</div>
+        <div class="tag-item">🔓 Free Quota Available</div>
+        <div class="tag-item">💰 Requires Payment</div>
+        <div class="tag-item">💪 Supports Latest Claude</div>
+        <div class="tag-item">✌ Supports Latest OpenAI</div>
+        <div class="tag-item">🎉 Other Models (e.g., DeepSeek)</div>
+        <div class="tag-item">🌎 International Network Required</div>
+        <div class="tag-item">🎁 Bonus Credits/Discounts</div>
+        <div class="tag-item">🚀 High Concurrency Support</div>
+        <div class="tag-item">😆 Daily Check-in Rewards</div>
+        <div class="tag-item">🚩 Verified Platform</div>
+        <div class="tag-item">✔ Verified Authenticity</div>
+      </div>
+    </div>
+    
+    <div class="section">
+      <h2>🌐 Third-Party API Providers</h2>
+      <div class="providers-table">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Platform</th>
+              <th>Link</th>
+              <th>Tags</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>chat01 (Recommended)</td><td><a href="https://chat01.ai/?ref=j45ikbTa" target="_blank">https://chat01.ai</a></td><td>🔓✌🎁💰✔</td><td>Supports Pro, solves degradation issues, 2 free credits/day, chat + API</td></tr>
+            <tr><td>2</td><td>SiliconFlow (Enterprise)</td><td><a href="https://cloud.siliconflow.cn/i/ZKV30bdG" target="_blank">https://cloud.siliconflow.cn</a></td><td>🔓🎉🚀🚩✔</td><td>Huawei Cloud Ascend service, ¥14 registration bonus</td></tr>
+            <tr><td>3</td><td>zenmux (Recommended)</td><td><a href="https://zenmux.ai/invite/U1QU1H" target="_blank">https://zenmux.ai</a></td><td>🔓✌🎁💰</td><td>Free Gemini 3 Pro, world's first compensated LLM aggregation</td></tr>
+            <tr><td>4</td><td>PoloAPI</td><td><a href="https://poloai.top" target="_blank">https://poloai.top</a></td><td>🔓💪✌🎉🎁💰</td><td>New users get $0.3, aggregates Claude/Grok/OpenAI models</td></tr>
+            <tr><td>5</td><td>OAIPro</td><td><a href="https://api.oaipro.com" target="_blank">https://api.oaipro.com</a></td><td>💰✌💪</td><td>Official pricing, stable connection, OpenAI & Claude support</td></tr>
+            <tr><td>6</td><td>VoAPI</td><td><a href="https://demo.voapi.top" target="_blank">https://demo.voapi.top</a></td><td>🆓😆💪✌</td><td>Free public platform, balance resets daily</td></tr>
+            <tr><td>7</td><td>inscopilot (Recommended)</td><td><a href="https://instcopilot-api.com/register?aff=Q2Z0" target="_blank">https://instcopilot-api.com</a></td><td>✌🎉😆🚀</td><td>$5 bonus, stable & cheap, supports CC</td></tr>
+            <tr><td>8</td><td>V3 API (Mixed)</td><td><a href="https://api.v3.cm" target="_blank">https://api.v3.cm</a></td><td>🚀🔓💪🎁🎉✌</td><td>$0.2 bonus, high concurrency, 30% recharge, many models</td></tr>
+            <tr><td>9</td><td>V3 API (Official)</td><td><a href="https://gf.gpt.ge" target="_blank">https://gf.gpt.ge</a></td><td>🚀🌹🔓💪</td><td>$0.2 bonus, high concurrency, 60% recharge</td></tr>
+            <tr><td>10</td><td>openai-hk</td><td><a href="https://openai-hk.com" target="_blank">https://openai-hk.com</a></td><td>🆓🔓🎉✌💪🚀</td><td>¥1 bonus, ultra-high concurrency, includes GPT-3.5 free version</td></tr>
+            <tr><td>11</td><td>ChatGPT API Faucet</td><td><a href="https://faucet.openkey.cloud" target="_blank">https://faucet.openkey.cloud</a></td><td>🆓</td><td>Free $1 credit, valid for 3 days</td></tr>
+            <tr><td>12</td><td>Free ChatGPT API</td><td><a href="https://github.com/popjane/free_chatgpt_api" target="_blank">GitHub</a></td><td>🆓</td><td>Free public service</td></tr>
+            <tr><td>13</td><td>GPT-API-free</td><td><a href="https://github.com/chuyuewei/ChatGPT-API" target="_blank">GitHub</a></td><td>🆓💪</td><td>Supports GPT-4, 3 calls per day</td></tr>
+            <tr><td>14</td><td>openkey</td><td><a href="https://openkey.cloud" target="_blank">https://openkey.cloud</a></td><td>🔓💪✌🚀</td><td>$0.2 bonus, multi-concurrency support</td></tr>
+            <tr><td>15</td><td>gptgod.online</td><td><a href="https://gptgod.online" target="_blank">https://gptgod.online</a></td><td>💪✌🎁💰🎉😆</td><td>Pay-per-use, credit system</td></tr>
+            <tr><td>16</td><td>m3.ckit.gold</td><td><a href="https://m3.ckit.gold" target="_blank">https://m3.ckit.gold</a></td><td>💰💪✌</td><td>¥3 per dollar, $0.1 signup bonus</td></tr>
+            <tr><td>17</td><td>iaicnn</td><td><a href="https://aicnn.cn" target="_blank">https://aicnn.cn</a></td><td>💪✌🎁💰🎉</td><td>API support for legacy users, migrated</td></tr>
+            <tr><td>18</td><td>goapi.gptnb.ai</td><td><a href="https://goapi.gptnb.ai" target="_blank">https://goapi.gptnb.ai</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>19</td><td>api.aigc369.com</td><td><a href="https://api.aigc369.com/pricing" target="_blank">https://api.aigc369.com</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>20</td><td>api.mjdjourney.cn</td><td><a href="https://api.mjdjourney.cn" target="_blank">https://api.mjdjourney.cn</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>21</td><td>api.bltcy.ai</td><td><a href="https://api.bltcy.ai" target="_blank">https://api.bltcy.ai</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>22</td><td>4Z API Relay</td><td><a href="https://zzzzapi.com" target="_blank">https://zzzzapi.com</a></td><td>🔓✌💪🎉🚀</td><td>Supports GPT-4o, Claude 3.5, $0.2 for new users</td></tr>
+            <tr><td>23</td><td>Simple API Relay</td><td><a href="https://jeniya.top" target="_blank">https://jeniya.top</a></td><td>🔓✌💪🎉🚀</td><td>Multi-model aggregation, no restrictions, ¥100 test credit</td></tr>
+            <tr><td>24</td><td>CloseAI</td><td><a href="https://closeai-asia.com" target="_blank">https://closeai-asia.com</a></td><td>💰✌💪🎉🚀</td><td>Enterprise proxy, GPT-4o & Claude 3.5, Chinese support</td></tr>
+            <tr><td>25</td><td>Cloud Whale AI</td><td><a href="https://api.atalk-ai.com" target="_blank">https://api.atalk-ai.com</a></td><td>🔓✌💪🎉🚀</td><td>Aggregates ChatGPT, Claude, Wenxin, ¥5 trial voucher</td></tr>
+            <tr><td>26</td><td>ModelBridge</td><td><a href="https://model-bridge.okeeper.com" target="_blank">https://model-bridge.okeeper.com</a></td><td>🔓✌💪🎉🚀</td><td>Free domestic proxy, OpenAI compatible with Chinese models</td></tr>
+            <tr><td>27</td><td>UiUi API</td><td><a href="https://sg.uiuiapi.com" target="_blank">https://sg.uiuiapi.com</a></td><td>🔓✌💪🎉🚀</td><td>Supports Claude 4, Gemini, OpenAI format compatible</td></tr>
+            <tr><td>28</td><td>LaoZhang API Relay</td><td><a href="https://api.laozhang.ai" target="_blank">https://api.laozhang.ai</a></td><td>🔓✌💪🎉🚀</td><td>Claude 3 & GPT-4o, ¥20 for new users, Alipay/WeChat</td></tr>
+            <tr><td>29</td><td>Haiwhale AI Platform</td><td><a href="https://ai.atalk-ai.com" target="_blank">https://ai.atalk-ai.com</a></td><td>🔓✌💪🎉🚀</td><td>Registered platform, unified multi-model API access</td></tr>
+            <tr><td>30</td><td>One API</td><td><a href="https://one-api.ai" target="_blank">https://one-api.ai</a></td><td>🔓✌💪🎉🚀</td><td>Open-source interface management, multi-model & private deployment</td></tr>
+            <tr><td>31</td><td>OpenRouter</td><td><a href="https://openrouter.ai" target="_blank">https://openrouter.ai</a></td><td>🔓✌💪🎉🚀</td><td>293 models (OpenAI, Claude, Gemini), free quota provided</td></tr>
+            <tr><td>32</td><td>Gemini API Proxy</td><td><a href="https://gemini-proxy.com" target="_blank">https://gemini-proxy.com</a></td><td>🔓✌🎉🚀</td><td>Google Gemini models, OpenAI compatible, free quota</td></tr>
+            <tr><td>33</td><td>DeepSeek API Aggregation</td><td><a href="https://deepseek-aggregator.com" target="_blank">https://deepseek-aggregator.com</a></td><td>🔓💪🎉🚀</td><td>DeepSeek series aggregation, free test quota</td></tr>
+            <tr><td>34</td><td>Hugging Face Inference</td><td><a href="https://huggingface.co/inference-api" target="_blank">https://huggingface.co/inference-api</a></td><td>🔓💪🎉🚀</td><td>Open-source models (Llama 3), free & enterprise tiers</td></tr>
+            <tr><td>35</td><td>AI21 Labs Official</td><td><a href="https://studio.ai21.com" target="_blank">https://studio.ai21.com</a></td><td>💰✌💪🎉</td><td>Jurassic-2 models, NLP tasks</td></tr>
+            <tr><td>36</td><td>Cohere API</td><td><a href="https://cohere.ai" target="_blank">https://cohere.ai</a></td><td>💰✌💪🎉</td><td>Text generation & classification, enterprise API</td></tr>
+            <tr><td>37</td><td>AI API Aggregator</td><td><a href="https://api.ai-aggregator.com" target="_blank">https://api.ai-aggregator.com</a></td><td>🔓✌💪🎉🚀</td><td>Multi-model aggregation, unified interface, load balancing</td></tr>
+            <tr><td>38</td><td>AI.LS</td><td><a href="https://ai.ls" target="_blank">https://ai.ls</a></td><td>🆓✌</td><td>Minimal interface, GPT-3.5 free anonymous use</td></tr>
+            <tr><td>39</td><td>Simple API</td><td><a href="https://jeniya.top" target="_blank">https://jeniya.top</a></td><td>🔓✌💪🎉🎁</td><td>¥100 signup credit, Claude/GPT-4o support</td></tr>
+            <tr><td>40</td><td>OpenAI120</td><td><a href="https://openai120.com" target="_blank">https://openai120.com</a></td><td>🔓✌🎁</td><td>$3 for new users, official pricing</td></tr>
+            <tr><td>41</td><td>DuckAGI</td><td><a href="https://duckagi.com" target="_blank">https://duckagi.com</a></td><td>💰✌🎉🚀</td><td>Multimodal GPT-4o/Sora, AI art generation</td></tr>
+            <tr><td>42</td><td>Aihubmix</td><td><a href="https://aihubmix.com" target="_blank">https://aihubmix.com</a></td><td>💰🎉</td><td>Chinese model aggregation (Wenxin/Tongyi)</td></tr>
+            <tr><td>43</td><td>WokaAI</td><td><a href="https://wokaai.com" target="_blank">https://wokaai.com</a></td><td>✌</td><td>Dual routes</td></tr>
+            <tr><td>44</td><td>azapi</td><td><a href="https://azapi.com.cn" target="_blank">https://azapi.com.cn</a></td><td>💰</td><td>Long-term user discounts</td></tr>
+            <tr><td>45</td><td>ClaudeAPI</td><td><a href="https://claudeapi.io" target="_blank">https://claudeapi.io</a></td><td>💪🚀✔</td><td>Anthropic official partnership, file parsing support</td></tr>
+            <tr><td>46</td><td>Gala API</td><td><a href="https://galaapi.com" target="_blank">https://galaapi.com</a></td><td>🎉🚀</td><td>Google Gemini dedicated high-speed channel</td></tr>
+            <tr><td>47</td><td>Google AI Studio</td><td><a href="https://ai.google.dev" target="_blank">https://ai.google.dev</a></td><td>🆓🌎✔</td><td>Gemini series completely free, VPN required</td></tr>
+            <tr><td>48</td><td>OpenAI Data Sharing</td><td><a href="https://platform.openai.com" target="_blank">https://platform.openai.com</a></td><td>🔓✌🌎</td><td>Up to 1M free tokens daily with data sharing enabled</td></tr>
+            <tr><td>49</td><td>Mistral AI Platform</td><td><a href="https://platform.mistral.ai" target="_blank">https://platform.mistral.ai</a></td><td>🔓🎉🌎</td><td>Official platform free API trial (rate limited)</td></tr>
+            <tr><td>50</td><td>Cohere</td><td><a href="https://cohere.com" target="_blank">https://cohere.com</a></td><td>🔓🎉🌎</td><td>Trial key on registration, free with rate limits</td></tr>
+            <tr><td>51</td><td>ModelScope</td><td><a href="https://modelscope.cn" target="_blank">https://modelscope.cn</a></td><td>🔓🎉🚩</td><td>Aggregates DeepSeek/Qwen, free model trial & download</td></tr>
+            <tr><td>52</td><td>ByteDance Ark Plan</td><td><a href="https://www.volcengine.com/product/ark" target="_blank">https://www.volcengine.com/product/ark</a></td><td>🔓🎉</td><td>500K tokens daily per model in collaboration plan</td></tr>
+            <tr><td>53</td><td>Zhipu BigModel</td><td><a href="https://open.bigmodel.cn" target="_blank">https://open.bigmodel.cn</a></td><td>🆓🎉</td><td>GLM-4-Flash API completely free, 128K context</td></tr>
+            <tr><td>54</td><td>InternLM</td><td><a href="https://internlm.intern-ai.org.cn" target="_blank">https://internlm.intern-ai.org.cn</a></td><td>🆓🎉</td><td>Official free API, direct access</td></tr>
+            <tr><td>55</td><td>GitHub Models</td><td><a href="https://docs.github.com/github-models" target="_blank">https://docs.github.com/github-models</a></td><td>🔓✌🎉🌎</td><td>Azure-hosted, limited free API quota</td></tr>
+            <tr><td>56</td><td>OpenRouter (Free)</td><td><a href="https://openrouter.ai" target="_blank">https://openrouter.ai</a></td><td>🔓💪✌🎉🌎✔</td><td>Free models ≤50 daily, ≥$10 balance upgrades to 1000</td></tr>
+            <tr><td>57</td><td>Chutes</td><td><a href="https://chutes.ai" target="_blank">https://chutes.ai</a></td><td>🔓🎉</td><td>Some models 200 free calls daily, DeepSeek support</td></tr>
+            <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>Free API key available, OpenAI compatible, ultra-fast inference</td></tr>
+            <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>Developers enjoy 1M free tokens daily, LLM inference 450+ t/s</td></tr>
+            <tr><td>60</td><td>Infini-AI GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>DeepSeek R1/V3 full version free tokens, no invite code needed</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    
+    <div class="section">
+      <h2>📱 Compatible Applications</h2>
+      <details>
+        <summary>📦 Click to view compatible apps</summary>
+        <div class="apps-grid">
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/CherryHQ/cherry-studio" target="_blank">Cherry Studio</a></h4>
+            <p>Cross-platform desktop/mobile client with cloud and local AI model integration.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://u.tools/plugins/detail/ChatGPT.%E5%A5%BD%E5%8F%8B/" target="_blank">ChatGPT Friends Plugin (uTools)</a></h4>
+            <p>Desktop AI chat tool supporting custom roles, multi-model, multi-session.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Yidadaa/ChatGPT-Next-Web" target="_blank">ChatGPT-Next-Web</a></h4>
+            <p>Open-source web front-end supporting API key and multi-user use.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/lobehub/lobe-chat" target="_blank">LobeChat</a></h4>
+            <p>Web-based AI chat framework supporting vision, speech, and multi-model interaction.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://botgem.com/" target="_blank">BotGem</a></h4>
+            <p>Mobile-first chat assistant with voice and AI friends.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Bin-Huang/chatbox" target="_blank">ChatBox</a></h4>
+            <p>Multi-platform AI chat client with a modern interface.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/labring/FastGPT" target="_blank">FastGPT</a></h4>
+            <p>Knowledge base + visual workflow for internal training or customer service.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank">AnythingLLM</a></h4>
+            <p>Privacy-focused local LLM deployment with plugin support.</p>
+          </div>
+        </div>
+      </details>
+    </div>
+    
+    <div class="section">
+      <h2>📖 How to Use</h2>
+      <ol class="usage-steps">
+        <li>🔑 <strong>Get API Key</strong>: Register on the target platform and find it in your dashboard</li>
+        <li>⚙ <strong>Set Endpoint</strong>: Add API URL into the supported app</li>
+        <li>🤖 <strong>Choose Model</strong>: Pick the model based on platform support</li>
+        <li>📊 <strong>Monitor Usage</strong>: Use in-app limits to track API usage</li>
+      </ol>
+    </div>
+    
+    <div class="section">
+      <h2>🙌 Contribution Guide</h2>
+      <p>We welcome:</p>
+      <ul style="margin-left: 20px; margin-top: 10px;">
+        <li>✨ New API platforms (must be stable ≥ 3 days)</li>
+        <li>🛠️ Usage tutorials (screenshots, screen recordings)</li>
+        <li>🧪 Automated scripts (detect dead platforms)</li>
+        <li>🌍 Translations (English, Japanese, Korean, etc.)</li>
+      </ul>
+      <p style="margin-top: 15px;">💡 PRs and issues are welcome!</p>
+    </div>
+    
+    <div class="section">
+      <h2>❌ Inactive Platforms</h2>
+      <details>
+        <summary>📛 Click to expand</summary>
+        <table style="width: 100%; margin-top: 15px;">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Name</th>
+              <th>Link</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>464888</td>
+              <td><a href="https://api.464888.xyz" target="_blank">api.464888.xyz</a></td>
+              <td>❌ Unavailable</td>
+            </tr>
+          </tbody>
+        </table>
+        <p style="margin-top: 10px;">💡 Found an inactive platform? Submit an issue!</p>
+      </details>
+    </div>
+    
+    <div class="section">
+      <h2>⚖️ Disclaimer</h2>
+      <ul style="margin-left: 20px;">
+        <li>We do not store API keys or provide proxy services.</li>
+        <li>All platforms listed are from the public internet.</li>
+        <li>Use at your own risk. We are not liable for any losses.</li>
+      </ul>
+    </div>
+    
+    <div class="section">
+      <h2>🙏 Special Thanks</h2>
+      <p>Many thanks to <strong>zenmux</strong> for providing API platform support!<br>
+      <a href="https://zenmux.ai/invite/U1QU1H" target="_blank">Register now and use invite code</a></p>
+      
+      <p style="margin-top: 15px;">Many thanks to <strong>chat01</strong> for providing service support!<br>
+      <a href="https://chat01.ai/?ref=j45ikbTa" target="_blank">Visit chat01 and use referral code</a></p>
+      
+      <p style="margin-top: 15px;">
+        <a href="https://dartnode.com" target="_blank">
+          <img src="https://dartnode.com/branding/DN-Open-Source-sm.png" alt="Powered by DartNode">
+        </a>
+      </p>
+    </div>
+    
+    <footer>
+      <p style="margin-bottom: 15px;">
+        <a href="https://star-history.com/#TechnologyStar/Openai-Claude-Deepseek-API-provider&Date" target="_blank">
+          <img src="https://api.star-history.com/svg?repos=TechnologyStar/Openai-Claude-Deepseek-API-provider&type=Date" alt="Star History" style="max-width: 100%; height: auto;">
+        </a>
+      </p>
+      <p>Made with ❤️ by <a href="https://github.com/TechnologyStar" target="_blank">TechnologyStar</a></p>
+      <p style="margin-top: 10px; font-size: 0.9em; color: #666;">
+        <a href="https://github.com/TechnologyStar/Openai-Claude-Deepseek-API-provider" target="_blank">GitHub Repository</a>
+      </p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/website/index.fr.html
+++ b/website/index.fr.html
@@ -1,0 +1,544 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>🌐 OpenAI / Claude / DeepSeek API Provider - Répertoire</title>
+  <meta name="description" content="Liste sélectionnée de plateformes tierces fournissant les API OpenAI / Claude / DeepSeek pour l'apprentissage, la recherche et un usage non commercial.">
+  <meta name="keywords" content="OpenAI, Claude, DeepSeek, API, tiers, gratuit, intelligence artificielle, IA">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
+    }
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    header {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      margin-bottom: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+      text-align: center;
+    }
+    h1 {
+      font-size: 2.5em;
+      margin-bottom: 15px;
+      color: #667eea;
+      text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    .subtitle {
+      font-size: 1.2em;
+      color: #666;
+      margin-bottom: 20px;
+    }
+    .badges {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin: 20px 0;
+    }
+    .badges img {
+      height: 20px;
+    }
+    .lang-switcher {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin-top: 20px;
+    }
+    .lang-btn {
+      padding: 8px 16px;
+      background: #667eea;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 20px;
+      font-size: 14px;
+      transition: all 0.3s;
+    }
+    .lang-btn:hover {
+      background: #764ba2;
+      transform: translateY(-2px);
+      box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+    }
+    .lang-btn.active {
+      background: #764ba2;
+    }
+    .section {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      margin-bottom: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    }
+    .notice {
+      background: #fff3cd;
+      border-left: 4px solid #ffc107;
+      border-radius: 10px;
+    }
+    h2 {
+      font-size: 2em;
+      margin-bottom: 20px;
+      color: #667eea;
+      border-bottom: 3px solid #667eea;
+      padding-bottom: 10px;
+    }
+    h3 {
+      font-size: 1.5em;
+      margin: 20px 0 10px;
+      color: #764ba2;
+    }
+    .tags-legend {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 10px;
+      margin: 20px 0;
+    }
+    .tag-item {
+      padding: 10px;
+      background: #f8f9fa;
+      border-radius: 8px;
+      border-left: 3px solid #667eea;
+    }
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+      margin: 20px 0;
+    }
+    .stat-card {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: #fff;
+      padding: 25px;
+      border-radius: 12px;
+      text-align: center;
+    }
+    .stat-number {
+      font-size: 3em;
+      font-weight: 700;
+      margin-bottom: 5px;
+    }
+    .stat-label {
+      font-size: 1.1em;
+      opacity: 0.9;
+    }
+    .providers-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 20px 0;
+      overflow-x: auto;
+      display: block;
+    }
+    .providers-table table {
+      width: 100%;
+      min-width: 900px;
+    }
+    .providers-table th,
+    .providers-table td {
+      padding: 12px;
+      border-bottom: 1px solid #e0e0e0;
+      text-align: left;
+    }
+    .providers-table th {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: #fff;
+      font-weight: 600;
+      position: sticky;
+      top: 0;
+    }
+    .providers-table tr:hover {
+      background: #f5f5f5;
+    }
+    .providers-table a {
+      color: #667eea;
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .providers-table a:hover {
+      text-decoration: underline;
+    }
+    .apps-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+      margin: 20px 0;
+    }
+    .app-card {
+      padding: 20px;
+      background: #f8f9fa;
+      border-radius: 12px;
+      border-left: 4px solid #667eea;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .app-card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+    }
+    .app-card h4 {
+      color: #667eea;
+      margin-bottom: 8px;
+    }
+    .usage-steps {
+      counter-reset: step;
+      list-style: none;
+      padding: 0;
+    }
+    .usage-steps li {
+      counter-increment: step;
+      padding: 15px 15px 15px 60px;
+      margin: 10px 0;
+      background: #f8f9fa;
+      border-radius: 12px;
+      position: relative;
+    }
+    .usage-steps li::before {
+      content: counter(step);
+      position: absolute;
+      left: 15px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: #fff;
+      width: 35px;
+      height: 35px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+    }
+    details {
+      margin: 20px 0;
+    }
+    summary {
+      cursor: pointer;
+      padding: 15px;
+      background: #f8f9fa;
+      border-radius: 10px;
+      font-weight: 600;
+      color: #667eea;
+      user-select: none;
+    }
+    summary:hover {
+      background: #e9ecef;
+    }
+    footer {
+      background: rgba(255, 255, 255, 0.95);
+      border-radius: 15px;
+      padding: 30px;
+      text-align: center;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+      margin-bottom: 20px;
+    }
+    footer a {
+      color: #667eea;
+      text-decoration: none;
+    }
+    footer a:hover {
+      text-decoration: underline;
+    }
+    @media (max-width: 768px) {
+      h1 {
+        font-size: 1.8em;
+      }
+      .providers-table {
+        font-size: 0.9em;
+      }
+      .container {
+        padding: 12px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🌐 OpenAI / Claude / DeepSeek API Provider</h1>
+      <p class="subtitle">Répertoire mondial des plateformes tierces offrant des API OpenAI / Claude / DeepSeek</p>
+      <p class="subtitle">Pour l'apprentissage, la recherche et tout usage non commercial</p>
+      <div class="badges">
+        <img src="https://img.shields.io/github/last-commit/TechnologyStar/Openai-Claude-Deepseek-API-provider" alt="Dernier commit">
+        <img src="https://img.shields.io/github/license/TechnologyStar/Openai-Claude-Deepseek-API-provider" alt="Licence">
+      </div>
+      <div class="lang-switcher">
+        <a href="index.zh-CN.html" class="lang-btn">🇨🇳 中文</a>
+        <a href="index.en.html" class="lang-btn">🇬🇧 English</a>
+        <a href="index.ru.html" class="lang-btn">🇷🇺 Русский</a>
+        <a href="index.fr.html" class="lang-btn active">🇫🇷 Français</a>
+      </div>
+    </header>
+
+    <section class="section notice">
+      <h3>⚠️ Instructions d'utilisation</h3>
+      <p><strong>Ce projet est gratuit et à but non lucratif. Toute utilisation illégale est strictement interdite.</strong></p>
+      <ul style="margin-top: 10px; margin-left: 20px;">
+        <li>Respectez les <a href="https://openai.com/policies/terms-of-use" target="_blank">conditions d'utilisation d'OpenAI</a></li>
+        <li>Respectez les lois locales concernant la fourniture de services d'IA générative</li>
+      </ul>
+    </section>
+
+    <section class="section">
+      <h2>🚀 Présentation du projet</h2>
+      <p>📌 Répertorie et vérifie les principales plateformes API (plusieurs gratuites)</p>
+      <p>🔧 Intégration sans inscription, connexion simple, support multi-modèles (OpenAI, Claude, DeepSeek, etc.)</p>
+      <p>🔒 Ces sites sont listés à titre d'information — <strong>n'entrez jamais de données sensibles</strong></p>
+      <p style="margin-top: 15px;">💡 Si le projet vous aide, laissez une étoile 🌟</p>
+    </section>
+
+    <section class="section">
+      <h2>📊 Statistiques</h2>
+      <div class="stats">
+        <div class="stat-card">
+          <div class="stat-number">60+</div>
+          <div class="stat-label">Fournisseurs API</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">20+</div>
+          <div class="stat-label">Plateformes gratuites</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">8</div>
+          <div class="stat-label">Applications recommandées</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>🎁 Légende des étiquettes</h2>
+      <div class="tags-legend">
+        <div class="tag-item">🆓 Entièrement gratuit</div>
+        <div class="tag-item">🔓 Crédit gratuit disponible</div>
+        <div class="tag-item">💰 Paiement requis</div>
+        <div class="tag-item">💪 Support des derniers modèles Claude</div>
+        <div class="tag-item">✌ Support des derniers modèles OpenAI</div>
+        <div class="tag-item">🎉 Autres modèles (ex. DeepSeek)</div>
+        <div class="tag-item">🌎 Accès international requis</div>
+        <div class="tag-item">🎁 Bonus ou remises à la recharge</div>
+        <div class="tag-item">🚀 Haute concurrence supportée</div>
+        <div class="tag-item">😆 Récompense quotidienne</div>
+        <div class="tag-item">🚩 Plateforme enregistrée</div>
+        <div class="tag-item">✔ Authenticité vérifiée</div>
+      </div>
+    </section>
+
+    <section class="section" id="providers">
+      <h2>🌐 Fournisseurs d’API tiers</h2>
+      <div class="providers-table">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Plateforme</th>
+              <th>Lien</th>
+              <th>Étiquettes</th>
+              <th>Remarques</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>chat01 (recommandé)</td><td><a href="https://chat01.ai/?ref=j45ikbTa" target="_blank">https://chat01.ai</a></td><td>🔓✌🎁💰✔</td><td>Supporte les comptes Pro, corrige les dégradations, 2 crédits gratuits/jour, chat + API</td></tr>
+            <tr><td>2</td><td>SiliconFlow (entreprise)</td><td><a href="https://cloud.siliconflow.cn/i/ZKV30bdG" target="_blank">https://cloud.siliconflow.cn</a></td><td>🔓🎉🚀🚩✔</td><td>Service Huawei Cloud Ascend, 14 ¥ offerts à l'inscription</td></tr>
+            <tr><td>3</td><td>zenmux (recommandé)</td><td><a href="https://zenmux.ai/invite/U1QU1H" target="_blank">https://zenmux.ai</a></td><td>🔓✌🎁💰</td><td>Gemini 3 Pro gratuit, premier agrégateur LLM avec compensation</td></tr>
+            <tr><td>4</td><td>PoloAPI</td><td><a href="https://poloai.top" target="_blank">https://poloai.top</a></td><td>🔓💪✌🎉🎁💰</td><td>$0,3 offerts aux nouveaux utilisateurs, agrège Claude/Grok/OpenAI</td></tr>
+            <tr><td>5</td><td>OAIPro</td><td><a href="https://api.oaipro.com" target="_blank">https://api.oaipro.com</a></td><td>💰✌💪</td><td>Tarifs officiels, connexion stable, support OpenAI & Claude</td></tr>
+            <tr><td>6</td><td>VoAPI</td><td><a href="https://demo.voapi.top" target="_blank">https://demo.voapi.top</a></td><td>🆓😆💪✌</td><td>Site public gratuit, solde remis à zéro chaque jour</td></tr>
+            <tr><td>7</td><td>inscopilot (recommandé)</td><td><a href="https://instcopilot-api.com/register?aff=Q2Z0" target="_blank">https://instcopilot-api.com</a></td><td>✌🎉😆🚀</td><td>$5 offerts, stable et économique, supporte les cartes internationales</td></tr>
+            <tr><td>8</td><td>V3 API (mixte)</td><td><a href="https://api.v3.cm" target="_blank">https://api.v3.cm</a></td><td>🚀🔓💪🎁🎉✌</td><td>$0,2 offerts, haute concurrence, recharge à -70 %, nombreux modèles</td></tr>
+            <tr><td>9</td><td>V3 API (officiel)</td><td><a href="https://gf.gpt.ge" target="_blank">https://gf.gpt.ge</a></td><td>🚀🌹🔓💪</td><td>$0,2 offerts, haute concurrence, recharge à -40 %</td></tr>
+            <tr><td>10</td><td>openai-hk</td><td><a href="https://openai-hk.com" target="_blank">https://openai-hk.com</a></td><td>🆓🔓🎉✌💪🚀</td><td>1 ¥ offert, très haute concurrence, inclut GPT-3.5 communautaire</td></tr>
+            <tr><td>11</td><td>ChatGPT API Faucet</td><td><a href="https://faucet.openkey.cloud" target="_blank">https://faucet.openkey.cloud</a></td><td>🆓</td><td>1 $ de crédit gratuit, valable 3 jours</td></tr>
+            <tr><td>12</td><td>API caritative ChatGPT</td><td><a href="https://github.com/popjane/free_chatgpt_api" target="_blank">GitHub</a></td><td>🆓</td><td>Projet open source gratuit</td></tr>
+            <tr><td>13</td><td>GPT-API-free</td><td><a href="https://github.com/chuyuewei/ChatGPT-API" target="_blank">GitHub</a></td><td>🆓💪</td><td>Supporte GPT-4, 3 requêtes par jour</td></tr>
+            <tr><td>14</td><td>openkey</td><td><a href="https://openkey.cloud" target="_blank">https://openkey.cloud</a></td><td>🔓💪✌🚀</td><td>$0,2 offerts, support multi-thread</td></tr>
+            <tr><td>15</td><td>gptgod.online</td><td><a href="https://gptgod.online" target="_blank">https://gptgod.online</a></td><td>💪✌🎁💰🎉😆</td><td>Paiement à l'usage, système de crédits</td></tr>
+            <tr><td>16</td><td>m3.ckit.gold</td><td><a href="https://m3.ckit.gold" target="_blank">https://m3.ckit.gold</a></td><td>💰💪✌</td><td>3 ¥ pour 1 $, bonus d'inscription $0,1</td></tr>
+            <tr><td>17</td><td>iaicnn</td><td><a href="https://aicnn.cn" target="_blank">https://aicnn.cn</a></td><td>💪✌🎁💰🎉</td><td>Support API pour anciens utilisateurs, nouvelle infrastructure</td></tr>
+            <tr><td>18</td><td>goapi.gptnb.ai</td><td><a href="https://goapi.gptnb.ai" target="_blank">https://goapi.gptnb.ai</a></td><td>💪✌🎁💰🎉</td><td>Passerelle multi-modèles axée sur GPT</td></tr>
+            <tr><td>19</td><td>api.aigc369.com</td><td><a href="https://api.aigc369.com/pricing" target="_blank">https://api.aigc369.com</a></td><td>💪✌🎁💰🎉</td><td>Tarifs flexibles, compatibilité OpenAI</td></tr>
+            <tr><td>20</td><td>api.mjdjourney.cn</td><td><a href="https://api.mjdjourney.cn" target="_blank">https://api.mjdjourney.cn</a></td><td>💪✌🎁💰🎉</td><td>Interface spécialisée pour Midjourney/GPT</td></tr>
+            <tr><td>21</td><td>api.bltcy.ai</td><td><a href="https://api.bltcy.ai" target="_blank">https://api.bltcy.ai</a></td><td>💪✌🎁💰🎉</td><td>Pont OpenAI/Claude, facturation flexible</td></tr>
+            <tr><td>22</td><td>4Z API Relay</td><td><a href="https://zzzzapi.com" target="_blank">https://zzzzapi.com</a></td><td>🔓✌💪🎉🚀</td><td>Supporte GPT-4o et Claude 3.5, bonus 0,2 pour les nouveaux comptes</td></tr>
+            <tr><td>23</td><td>Simple API Relay</td><td><a href="https://jeniya.top" target="_blank">https://jeniya.top</a></td><td>🔓✌💪🎉🚀</td><td>Multi-modèles, accès domestique illimité, 100 ¥ de tests</td></tr>
+            <tr><td>24</td><td>CloseAI</td><td><a href="https://closeai-asia.com" target="_blank">https://closeai-asia.com</a></td><td>💰✌💪🎉🚀</td><td>Proxy entreprise, GPT-4o/Claude 3.5, support technique chinois</td></tr>
+            <tr><td>25</td><td>Cloud Whale AI</td><td><a href="https://api.atalk-ai.com" target="_blank">https://api.atalk-ai.com</a></td><td>🔓✌💪🎉🚀</td><td>Unifie ChatGPT, Claude, Wenxin, bon d'essai 5 ¥</td></tr>
+            <tr><td>26</td><td>ModelBridge</td><td><a href="https://model-bridge.okeeper.com" target="_blank">https://model-bridge.okeeper.com</a></td><td>🔓✌💪🎉🚀</td><td>Proxy gratuit, compatible OpenAI et modèles chinois</td></tr>
+            <tr><td>27</td><td>UiUi API</td><td><a href="https://sg.uiuiapi.com" target="_blank">https://sg.uiuiapi.com</a></td><td>🔓✌💪🎉🚀</td><td>Claude 4, Gemini, format OpenAI compatible</td></tr>
+            <tr><td>28</td><td>LaoZhang API</td><td><a href="https://api.laozhang.ai" target="_blank">https://api.laozhang.ai</a></td><td>🔓✌💪🎉🚀</td><td>Supporte Claude 3/GPT-4o, 20 ¥ offerts, paiement local</td></tr>
+            <tr><td>29</td><td>Haiwhale AI</td><td><a href="https://ai.atalk-ai.com" target="_blank">https://ai.atalk-ai.com</a></td><td>🔓✌💪🎉🚀</td><td>Plateforme enregistrée, accès API unifié multi-modèles</td></tr>
+            <tr><td>30</td><td>One API</td><td><a href="https://one-api.ai" target="_blank">https://one-api.ai</a></td><td>🔓✌💪🎉🚀</td><td>Gestion open source des clés API, support du déploiement privé</td></tr>
+            <tr><td>31</td><td>OpenRouter</td><td><a href="https://openrouter.ai" target="_blank">https://openrouter.ai</a></td><td>🔓✌💪🎉🚀</td><td>293 modèles (OpenAI, Claude, Gemini), quota gratuit fourni</td></tr>
+            <tr><td>32</td><td>Gemini API Proxy</td><td><a href="https://gemini-proxy.com" target="_blank">https://gemini-proxy.com</a></td><td>🔓✌🎉🚀</td><td>Proxy dédié Google Gemini, compatible OpenAI, crédits offerts</td></tr>
+            <tr><td>33</td><td>DeepSeek Aggregator</td><td><a href="https://deepseek-aggregator.com" target="_blank">https://deepseek-aggregator.com</a></td><td>🔓💪🎉🚀</td><td>Spécialisé DeepSeek, crédits de test gratuits</td></tr>
+            <tr><td>34</td><td>Hugging Face Inference</td><td><a href="https://huggingface.co/inference-api" target="_blank">https://huggingface.co/inference-api</a></td><td>🔓💪🎉🚀</td><td>Supporte Llama 3 et modèles open source, niveau gratuit disponible</td></tr>
+            <tr><td>35</td><td>AI21 Labs</td><td><a href="https://studio.ai21.com" target="_blank">https://studio.ai21.com</a></td><td>💰✌💪🎉</td><td>Jurassic-2 pour les tâches NLP professionnelles</td></tr>
+            <tr><td>36</td><td>Cohere API</td><td><a href="https://cohere.ai" target="_blank">https://cohere.ai</a></td><td>💰✌💪🎉</td><td>Génération et classification de texte, API entreprise</td></tr>
+            <tr><td>37</td><td>AI API Aggregator</td><td><a href="https://api.ai-aggregator.com" target="_blank">https://api.ai-aggregator.com</a></td><td>🔓✌💪🎉🚀</td><td>Orchestration multi-modèles, interface unifiée</td></tr>
+            <tr><td>38</td><td>AI.LS</td><td><a href="https://ai.ls" target="_blank">https://ai.ls</a></td><td>🆓✌</td><td>Interface minimaliste, GPT-3.5 gratuit et anonyme</td></tr>
+            <tr><td>39</td><td>Simple API</td><td><a href="https://jeniya.top" target="_blank">https://jeniya.top</a></td><td>🔓✌💪🎉🎁</td><td>100 ¥ offerts à l'inscription, support Claude/GPT-4o</td></tr>
+            <tr><td>40</td><td>OpenAI120</td><td><a href="https://openai120.com" target="_blank">https://openai120.com</a></td><td>🔓✌🎁</td><td>$3 offerts, même tarification que l'officiel</td></tr>
+            <tr><td>41</td><td>DuckAGI</td><td><a href="https://duckagi.com" target="_blank">https://duckagi.com</a></td><td>💰✌🎉🚀</td><td>Support multimodal GPT-4o/Sora, pensé pour la créativité</td></tr>
+            <tr><td>42</td><td>Aihubmix</td><td><a href="https://aihubmix.com" target="_blank">https://aihubmix.com</a></td><td>💰🎉</td><td>Agrégation de modèles chinois (Wenxin, Tongyi)</td></tr>
+            <tr><td>43</td><td>WokaAI</td><td><a href="https://wokaai.com" target="_blank">https://wokaai.com</a></td><td>✌</td><td>Double routage vers les modèles OpenAI</td></tr>
+            <tr><td>44</td><td>azapi</td><td><a href="https://azapi.com.cn" target="_blank">https://azapi.com.cn</a></td><td>💰</td><td>Réductions pour les utilisateurs de longue durée</td></tr>
+            <tr><td>45</td><td>ClaudeAPI</td><td><a href="https://claudeapi.io" target="_blank">https://claudeapi.io</a></td><td>💪🚀✔</td><td>Partenaire officiel Anthropic, supporte l'analyse de fichiers</td></tr>
+            <tr><td>46</td><td>Gala API</td><td><a href="https://galaapi.com" target="_blank">https://galaapi.com</a></td><td>🎉🚀</td><td>Canal haute vitesse dédié aux modèles Gemini</td></tr>
+            <tr><td>47</td><td>Google AI Studio</td><td><a href="https://ai.google.dev" target="_blank">https://ai.google.dev</a></td><td>🆓🌎✔</td><td>API Gemini gratuite, nécessite un accès international</td></tr>
+            <tr><td>48</td><td>Programme OpenAI Data Sharing</td><td><a href="https://platform.openai.com" target="_blank">https://platform.openai.com</a></td><td>🔓✌🌎</td><td>Jusqu'à 1M de jetons gratuits/jour avec partage de données activé</td></tr>
+            <tr><td>49</td><td>Mistral AI Platform</td><td><a href="https://platform.mistral.ai" target="_blank">https://platform.mistral.ai</a></td><td>🔓🎉🌎</td><td>Essai API officiel gratuit (débit limité)</td></tr>
+            <tr><td>50</td><td>Cohere</td><td><a href="https://cohere.com" target="_blank">https://cohere.com</a></td><td>🔓🎉🌎</td><td>Clé d'essai offerte, appels gratuits limités</td></tr>
+            <tr><td>51</td><td>ModelScope</td><td><a href="https://modelscope.cn" target="_blank">https://modelscope.cn</a></td><td>🔓🎉🚩</td><td>Agrège DeepSeek/Qwen, essais et téléchargements gratuits</td></tr>
+            <tr><td>52</td><td>Programme ByteDance Ark</td><td><a href="https://www.volcengine.com/product/ark" target="_blank">https://www.volcengine.com/product/ark</a></td><td>🔓🎉</td><td>Jusqu'à 500k tokens/jour par modèle pour les collaborateurs</td></tr>
+            <tr><td>53</td><td>Zhipu BigModel</td><td><a href="https://open.bigmodel.cn" target="_blank">https://open.bigmodel.cn</a></td><td>🆓🎉</td><td>GLM-4-Flash gratuit, contexte 128K</td></tr>
+            <tr><td>54</td><td>InternLM</td><td><a href="https://internlm.intern-ai.org.cn" target="_blank">https://internlm.intern-ai.org.cn</a></td><td>🆓🎉</td><td>API officielle gratuite, accès direct</td></tr>
+            <tr><td>55</td><td>GitHub Models</td><td><a href="https://docs.github.com/github-models" target="_blank">https://docs.github.com/github-models</a></td><td>🔓✌🎉🌎</td><td>Hébergé sur Azure, quota gratuit limité</td></tr>
+            <tr><td>56</td><td>OpenRouter (gratuit)</td><td><a href="https://openrouter.ai" target="_blank">https://openrouter.ai</a></td><td>🔓💪✌🎉🌎✔</td><td>Modèles gratuits ≤50/jour, passe à 1000 avec ≥10 $ de solde</td></tr>
+            <tr><td>57</td><td>Chutes</td><td><a href="https://chutes.ai" target="_blank">https://chutes.ai</a></td><td>🔓🎉</td><td>Certains modèles 200 appels gratuits/jour, support DeepSeek</td></tr>
+            <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>Clé API gratuite, compatible OpenAI, inférence ultra rapide</td></tr>
+            <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>1M tokens gratuits par jour, 450 t/s+ pour les LLM</td></tr>
+            <tr><td>60</td><td>Infini-AI GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>DeepSeek R1/V3 complet gratuit, sans code d'invitation</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="section" id="apps">
+      <h2>📱 Applications compatibles</h2>
+      <details>
+        <summary>📦 Cliquez pour afficher la liste complète</summary>
+        <div class="apps-grid">
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/CherryHQ/cherry-studio" target="_blank">Cherry Studio</a></h4>
+            <p>Application desktop/mobile intégrant services cloud et modèles locaux.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://u.tools/plugins/detail/ChatGPT.%E5%A5%BD%E5%8F%8B/" target="_blank">Plugin ChatGPT pour uTools</a></h4>
+            <p>Plugin de chat intelligent, rôles personnalisés, multi-modèles.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Yidadaa/ChatGPT-Next-Web" target="_blank">ChatGPT-Next-Web</a></h4>
+            <p>Interface web open-source, gestion multi-utilisateurs et API Key.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/lobehub/lobe-chat" target="_blank">LobeChat</a></h4>
+            <p>Cadre web supportant voix, vision et changement de modèles.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://botgem.com/" target="_blank">BotGem</a></h4>
+            <p>Application mobile centrée sur la voix et les compagnons IA.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Bin-Huang/chatbox" target="_blank">ChatBox</a></h4>
+            <p>Client IA moderne pour iOS, Android et desktop.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/labring/FastGPT" target="_blank">FastGPT</a></h4>
+            <p>Base de connaissances + workflow visuel pour l'entreprise.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank">AnythingLLM</a></h4>
+            <p>Déploiement local axé confidentialité avec plugins.</p>
+          </div>
+        </div>
+      </details>
+    </section>
+
+    <section class="section" id="guide">
+      <h2>📖 Guide d'utilisation</h2>
+      <ol class="usage-steps">
+        <li>🔑 <strong>Obtenez votre API Key :</strong> inscrivez-vous et copiez la clé dans votre tableau de bord.</li>
+        <li>⚙ <strong>Configurez l'endpoint :</strong> ajoutez l'URL de l'API dans l'application compatible.</li>
+        <li>🤖 <strong>Choisissez le modèle :</strong> sélectionnez GPT, Claude, DeepSeek selon les supports.</li>
+        <li>📊 <strong>Surveillez l'usage :</strong> activez les limites ou notifications de consommation.</li>
+      </ol>
+    </section>
+
+    <section class="section" id="contribute">
+      <h2>🙌 Guide de contribution</h2>
+      <p>Nous acceptons volontiers :</p>
+      <ul style="margin-left: 20px; margin-top: 10px;">
+        <li>✨ Ajout de nouveaux fournisseurs (fiables ≥ 3 jours)</li>
+        <li>🧰 Tutoriels et captures d'écran</li>
+        <li>🧪 Scripts pour détecter les plateformes inactives</li>
+        <li>🌍 Traductions supplémentaires (anglais, japonais, coréen, etc.)</li>
+      </ul>
+      <p style="margin-top: 15px;">💡 Envoyez une Pull Request ou ouvrez un Issue, nous répondrons rapidement.</p>
+    </section>
+
+    <section class="section">
+      <h2>❌ Plateformes inactives</h2>
+      <details>
+        <summary>📛 Cliquez pour voir les entrées signalées</summary>
+        <table style="width: 100%; margin-top: 15px;">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Nom</th>
+              <th>Lien</th>
+              <th>Statut</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>464888</td>
+              <td><a href="https://api.464888.xyz" target="_blank">api.464888.xyz</a></td>
+              <td>❌ Inaccessible</td>
+            </tr>
+          </tbody>
+        </table>
+        <p style="margin-top: 10px;">💡 Vous avez trouvé une nouvelle plateforme HS ? Merci de créer un Issue.</p>
+      </details>
+    </section>
+
+    <section class="section">
+      <h2>⚖️ Avertissement</h2>
+      <ul style="margin-left: 20px;">
+        <li>Nous ne stockons aucune clé API et ne proposons pas de service proxy.</li>
+        <li>Toutes les plateformes proviennent d'Internet public. Utilisez-les à vos risques.</li>
+        <li>L'auteur n'est pas responsable des pertes éventuelles causées par ces services tiers.</li>
+      </ul>
+    </section>
+
+    <section class="section">
+      <h2>🙏 Remerciements</h2>
+      <p>Un grand merci à <strong>zenmux</strong> pour le soutien de la plateforme API.<br>
+        <a href="https://zenmux.ai/invite/U1QU1H" target="_blank">S'inscrire et profiter du code promo</a>
+      </p>
+      <p style="margin-top: 15px;">Merci à <strong>chat01</strong> pour le support technique.<br>
+        <a href="https://chat01.ai/?ref=j45ikbTa" target="_blank">Visiter chat01 et utiliser le code de parrainage</a>
+      </p>
+      <p style="margin-top: 15px;">
+        <a href="https://dartnode.com" target="_blank">
+          <img src="https://dartnode.com/branding/DN-Open-Source-sm.png" alt="Powered by DartNode">
+        </a>
+      </p>
+    </section>
+
+    <footer>
+      <p style="margin-bottom: 15px;">
+        <a href="https://star-history.com/#TechnologyStar/Openai-Claude-Deepseek-API-provider&Date" target="_blank">
+          <img src="https://api.star-history.com/svg?repos=TechnologyStar/Openai-Claude-Deepseek-API-provider&type=Date" alt="Star History" style="max-width: 100%; height: auto;">
+        </a>
+      </p>
+      <p>Réalisé avec ❤️ par <a href="https://github.com/TechnologyStar" target="_blank">TechnologyStar</a></p>
+      <p style="margin-top: 10px; font-size: 0.9em; color: #666;">
+        <a href="https://github.com/TechnologyStar/Openai-Claude-Deepseek-API-provider" target="_blank">Consulter le dépôt GitHub</a>
+      </p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>🌐 OpenAI / Claude / DeepSeek API Provider Directory</title>
+  <meta http-equiv="refresh" content="0; url=index.zh-CN.html">
+  <script>
+    // Detect browser language and redirect
+    const browserLang = navigator.language || navigator.userLanguage;
+    const lang = browserLang.toLowerCase();
+    
+    if (lang.startsWith('en')) {
+      window.location.href = 'index.en.html';
+    } else if (lang.startsWith('ru')) {
+      window.location.href = 'index.ru.html';
+    } else if (lang.startsWith('fr')) {
+      window.location.href = 'index.fr.html';
+    } else {
+      window.location.href = 'index.zh-CN.html';
+    }
+  </script>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: #fff;
+    }
+    .loading {
+      text-align: center;
+    }
+    .loading h1 {
+      font-size: 3em;
+      margin-bottom: 20px;
+    }
+    .loading p {
+      font-size: 1.2em;
+    }
+    .lang-links {
+      margin-top: 30px;
+    }
+    .lang-links a {
+      display: inline-block;
+      margin: 10px;
+      padding: 12px 24px;
+      background: rgba(255, 255, 255, 0.2);
+      color: #fff;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+      transition: all 0.3s;
+    }
+    .lang-links a:hover {
+      background: rgba(255, 255, 255, 0.3);
+      transform: translateY(-2px);
+    }
+  </style>
+</head>
+<body>
+  <div class="loading">
+    <h1>🌐</h1>
+    <p>Redirecting to your language version...</p>
+    <p>正在跳转到您的语言版本...</p>
+    <div class="lang-links">
+      <p>Or choose manually / 或手动选择：</p>
+      <a href="index.zh-CN.html">🇨🇳 中文</a>
+      <a href="index.en.html">🇬🇧 English</a>
+      <a href="index.ru.html">🇷🇺 Русский</a>
+      <a href="index.fr.html">🇫🇷 Français</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/website/index.ru.html
+++ b/website/index.ru.html
@@ -1,0 +1,589 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>🌐 OpenAI / Claude / DeepSeek API Provider - Каталог поставщиков</title>
+  <meta name="description" content="Курированный список сторонних платформ, предоставляющих API OpenAI / Claude / DeepSeek для обучения, исследований и некоммерческого использования.">
+  <meta name="keywords" content="OpenAI, Claude, DeepSeek, API, сторонние, бесплатно, искусственный интеллект, ИИ">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
+    }
+    
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    
+    header {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      margin-bottom: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+      text-align: center;
+    }
+    
+    h1 {
+      font-size: 2.5em;
+      margin-bottom: 15px;
+      color: #667eea;
+      text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    
+    .subtitle {
+      font-size: 1.2em;
+      color: #666;
+      margin-bottom: 20px;
+    }
+    
+    .badges {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin: 20px 0;
+    }
+    
+    .badges img {
+      height: 20px;
+    }
+    
+    .lang-switcher {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      margin-top: 20px;
+      flex-wrap: wrap;
+    }
+    
+    .lang-btn {
+      padding: 8px 16px;
+      background: #667eea;
+      color: white;
+      text-decoration: none;
+      border-radius: 20px;
+      font-size: 14px;
+      transition: all 0.3s;
+    }
+    
+    .lang-btn:hover {
+      background: #764ba2;
+      transform: translateY(-2px);
+      box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+    }
+    
+    .lang-btn.active {
+      background: #764ba2;
+    }
+    
+    .notice {
+      background: #fff3cd;
+      border-left: 4px solid #ffc107;
+      padding: 20px;
+      border-radius: 10px;
+      margin-bottom: 30px;
+    }
+    
+    .section {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      margin-bottom: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    }
+    
+    h2 {
+      font-size: 2em;
+      margin-bottom: 20px;
+      color: #667eea;
+      border-bottom: 3px solid #667eea;
+      padding-bottom: 10px;
+    }
+    
+    h3 {
+      font-size: 1.5em;
+      margin: 20px 0 10px;
+      color: #764ba2;
+    }
+    
+    .tags-legend {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 10px;
+      margin: 20px 0;
+    }
+    
+    .tag-item {
+      padding: 10px;
+      background: #f8f9fa;
+      border-radius: 8px;
+      border-left: 3px solid #667eea;
+    }
+    
+    .providers-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 20px 0;
+      overflow-x: auto;
+      display: block;
+    }
+    
+    .providers-table table {
+      width: 100%;
+      min-width: 800px;
+    }
+    
+    .providers-table th,
+    .providers-table td {
+      padding: 12px;
+      text-align: left;
+      border-bottom: 1px solid #e0e0e0;
+    }
+    
+    .providers-table th {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      font-weight: 600;
+      position: sticky;
+      top: 0;
+    }
+    
+    .providers-table tr:hover {
+      background: #f5f5f5;
+    }
+    
+    .providers-table a {
+      color: #667eea;
+      text-decoration: none;
+      font-weight: 500;
+    }
+    
+    .providers-table a:hover {
+      text-decoration: underline;
+    }
+    
+    .apps-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 20px;
+      margin: 20px 0;
+    }
+    
+    .app-card {
+      padding: 20px;
+      background: #f8f9fa;
+      border-radius: 10px;
+      border-left: 4px solid #667eea;
+      transition: all 0.3s;
+    }
+    
+    .app-card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+    }
+    
+    .app-card h4 {
+      color: #667eea;
+      margin-bottom: 10px;
+    }
+    
+    .usage-steps {
+      counter-reset: step;
+      list-style: none;
+      padding: 0;
+    }
+    
+    .usage-steps li {
+      counter-increment: step;
+      padding: 15px;
+      margin: 10px 0;
+      background: #f8f9fa;
+      border-radius: 10px;
+      position: relative;
+      padding-left: 60px;
+    }
+    
+    .usage-steps li::before {
+      content: counter(step);
+      position: absolute;
+      left: 15px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      width: 35px;
+      height: 35px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+    }
+    
+    footer {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      text-align: center;
+      margin-top: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    }
+    
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+      margin: 20px 0;
+    }
+    
+    .stat-card {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 25px;
+      border-radius: 10px;
+      text-align: center;
+    }
+    
+    .stat-number {
+      font-size: 3em;
+      font-weight: bold;
+      margin-bottom: 5px;
+    }
+    
+    .stat-label {
+      font-size: 1.1em;
+      opacity: 0.9;
+    }
+    
+    @media (max-width: 768px) {
+      h1 {
+        font-size: 1.8em;
+      }
+      
+      .providers-table {
+        font-size: 14px;
+      }
+      
+      .container {
+        padding: 10px;
+      }
+    }
+    
+    details {
+      margin: 20px 0;
+    }
+    
+    summary {
+      cursor: pointer;
+      padding: 15px;
+      background: #f8f9fa;
+      border-radius: 10px;
+      font-weight: 600;
+      color: #667eea;
+      user-select: none;
+    }
+    
+    summary:hover {
+      background: #e9ecef;
+    }
+    
+    details[open] summary {
+      margin-bottom: 15px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🌐 Поставщики API OpenAI / Claude / DeepSeek</h1>
+      <p class="subtitle">Курированный список сторонних платформ,</p>
+      <p class="subtitle">предоставляющих API для обучения, исследований и некоммерческого использования</p>
+      
+      <div class="badges">
+        <img src="https://img.shields.io/github/last-commit/TechnologyStar/Openai-Claude-Deepseek-API-provider" alt="Last Commit">
+        <img src="https://img.shields.io/github/license/TechnologyStar/Openai-Claude-Deepseek-API-provider" alt="License">
+      </div>
+      
+      <div class="lang-switcher">
+        <a href="index.zh-CN.html" class="lang-btn">🇨🇳 中文</a>
+        <a href="index.en.html" class="lang-btn">🇬🇧 English</a>
+        <a href="index.ru.html" class="lang-btn active">🇷🇺 Русский</a>
+        <a href="index.fr.html" class="lang-btn">🇫🇷 Français</a>
+      </div>
+    </header>
+    
+    <div class="notice section">
+      <h3>⚠️ Инструкция по использованию</h3>
+      <p><strong>Проект бесплатный и некоммерческий. Любое незаконное использование запрещено.</strong></p>
+      <ul style="margin-top: 10px; margin-left: 20px;">
+        <li>Соблюдайте <a href="https://openai.com/policies/terms-of-use" target="_blank">условия использования OpenAI</a></li>
+        <li>Соблюдайте местные законы и правила, касающиеся генеративных AI-сервисов</li>
+      </ul>
+    </div>
+    
+    <div class="section">
+      <h2>🚀 Описание проекта</h2>
+      <p>📌 Сбор и верификация сторонних платформ API из интернета (некоторые бесплатны)</p>
+      <p>🔧 Без регистрации / подключение в один клик / поддержка нескольких моделей (OpenAI, Claude, DeepSeek и др.)</p>
+      <p>🔒 Все сайты указаны только как ссылки — <strong>не вводите личные данные</strong></p>
+      <p style="margin-top: 15px;">💡 Если проект оказался полезным, поставьте звезду 🌟</p>
+    </div>
+    
+    <div class="section">
+      <h2>📊 Статистика</h2>
+      <div class="stats">
+        <div class="stat-card">
+          <div class="stat-number">60+</div>
+          <div class="stat-label">Поставщиков API</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">20+</div>
+          <div class="stat-label">Бесплатных платформ</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">8</div>
+          <div class="stat-label">Рекомендуемых приложений</div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="section">
+      <h2>🎁 Обозначения меток</h2>
+      <div class="tags-legend">
+        <div class="tag-item">🆓 Полностью бесплатно</div>
+        <div class="tag-item">🔓 Есть бесплатный кредит</div>
+        <div class="tag-item">💰 Платная услуга</div>
+        <div class="tag-item">💪 Поддержка последней версии Claude</div>
+        <div class="tag-item">✌ Поддержка последней версии OpenAI</div>
+        <div class="tag-item">🎉 Поддержка других моделей (DeepSeek)</div>
+        <div class="tag-item">🌎 Требуется международный доступ</div>
+        <div class="tag-item">🎁 Бонус при пополнении счета</div>
+        <div class="tag-item">🚀 Высокая производительность</div>
+        <div class="tag-item">😆 Ежедневный бесплатный кредит</div>
+        <div class="tag-item">🚩 Проверенная платформа</div>
+        <div class="tag-item">✔ Подлинность подтверждена</div>
+      </div>
+    </div>
+    
+    <div class="section">
+      <h2>🌐 Список поставщиков API</h2>
+      <div class="providers-table">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Платформа</th>
+              <th>Ссылка</th>
+              <th>Метки</th>
+              <th>Примечания</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>chat01 (рекомендуется)</td><td><a href="https://chat01.ai/?ref=j45ikbTa" target="_blank">https://chat01.ai</a></td><td>🔓✌🎁💰✔</td><td>Поддержка pro, решает проблему снижения качества, 2 кредита в день, чат + API</td></tr>
+            <tr><td>2</td><td>SiliconFlow (корпоративный)</td><td><a href="https://cloud.siliconflow.cn/i/ZKV30bdG" target="_blank">https://cloud.siliconflow.cn</a></td><td>🔓🎉🚀🚩✔</td><td>Сервис Ascend от Huawei Cloud, при регистрации 14 ¥</td></tr>
+            <tr><td>3</td><td>zenmux (рекомендуется)</td><td><a href="https://zenmux.ai/invite/U1QU1H" target="_blank">https://zenmux.ai</a></td><td>🔓✌🎁💰</td><td>Бесплатный Gemini 3 Pro, первая в мире компенсируемая агрегация LLM</td></tr>
+            <tr><td>4</td><td>PoloAPI</td><td><a href="https://poloai.top" target="_blank">https://poloai.top</a></td><td>🔓💪✌🎉🎁💰</td><td>Новые пользователи получают $0.3, агрегирует Claude/Grok/OpenAI</td></tr>
+            <tr><td>5</td><td>OAIPro</td><td><a href="https://api.oaipro.com" target="_blank">https://api.oaipro.com</a></td><td>💰✌💪</td><td>Официальные тарифы, стабильное соединение, поддержка OpenAI и Claude</td></tr>
+            <tr><td>6</td><td>VoAPI</td><td><a href="https://demo.voapi.top" target="_blank">https://demo.voapi.top</a></td><td>🆓😆💪✌</td><td>Бесплатная общественная платформа, баланс сбрасывается ежедневно</td></tr>
+            <tr><td>7</td><td>inscopilot (рекомендуется)</td><td><a href="https://instcopilot-api.com/register?aff=Q2Z0" target="_blank">https://instcopilot-api.com</a></td><td>✌🎉😆🚀</td><td>Бонус $5, стабильно и дешево, поддержка CC</td></tr>
+            <tr><td>8</td><td>V3 API (смешанная)</td><td><a href="https://api.v3.cm" target="_blank">https://api.v3.cm</a></td><td>🚀🔓💪🎁🎉✌</td><td>Бонус $0.2, высокая нагрузка, скидка 70%, много моделей</td></tr>
+            <tr><td>9</td><td>V3 API (официальная)</td><td><a href="https://gf.gpt.ge" target="_blank">https://gf.gpt.ge</a></td><td>🚀🌹🔓💪</td><td>Бонус $0.2, высокая нагрузка, скидка 60%</td></tr>
+            <tr><td>10</td><td>openai-hk</td><td><a href="https://openai-hk.com" target="_blank">https://openai-hk.com</a></td><td>🆓🔓🎉✌💪🚀</td><td>Бонус 1 ¥, сверхвысокая конкуренция, включает GPT-3.5 публичную версию</td></tr>
+            <tr><td>11</td><td>ChatGPT API Faucet</td><td><a href="https://faucet.openkey.cloud" target="_blank">https://faucet.openkey.cloud</a></td><td>🆓</td><td>$1 бесплатного кредита, действует 3 дня</td></tr>
+            <tr><td>12</td><td>Бесплатный ChatGPT API</td><td><a href="https://github.com/popjane/free_chatgpt_api" target="_blank">GitHub</a></td><td>🆓</td><td>Полностью бесплатно</td></tr>
+            <tr><td>13</td><td>GPT-API-free</td><td><a href="https://github.com/chuyuewei/ChatGPT-API" target="_blank">GitHub</a></td><td>🆓💪</td><td>Поддержка GPT-4, 3 запроса в день</td></tr>
+            <tr><td>14</td><td>openkey</td><td><a href="https://openkey.cloud" target="_blank">https://openkey.cloud</a></td><td>🔓💪✌🚀</td><td>Бонус $0.2, поддержка высокой нагрузки</td></tr>
+            <tr><td>15</td><td>gptgod.online</td><td><a href="https://gptgod.online" target="_blank">https://gptgod.online</a></td><td>💪✌🎁💰🎉😆</td><td>Оплата за запрос, система кредитов</td></tr>
+            <tr><td>16</td><td>m3.ckit.gold</td><td><a href="https://m3.ckit.gold" target="_blank">https://m3.ckit.gold</a></td><td>💰💪✌</td><td>3 ¥ за доллар, бонус $0.1 при регистрации</td></tr>
+            <tr><td>17</td><td>iaicnn</td><td><a href="https://aicnn.cn" target="_blank">https://aicnn.cn</a></td><td>💪✌🎁💰🎉</td><td>Поддержка API для старых пользователей, мигрирован</td></tr>
+            <tr><td>18</td><td>goapi.gptnb.ai</td><td><a href="https://goapi.gptnb.ai" target="_blank">https://goapi.gptnb.ai</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>19</td><td>api.aigc369.com</td><td><a href="https://api.aigc369.com/pricing" target="_blank">https://api.aigc369.com</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>20</td><td>api.mjdjourney.cn</td><td><a href="https://api.mjdjourney.cn" target="_blank">https://api.mjdjourney.cn</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>21</td><td>api.bltcy.ai</td><td><a href="https://api.bltcy.ai" target="_blank">https://api.bltcy.ai</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>22</td><td>4Z API Relay</td><td><a href="https://zzzzapi.com" target="_blank">https://zzzzapi.com</a></td><td>🔓✌💪🎉🚀</td><td>Поддержка GPT-4o, Claude 3.5, $0.2 для новых пользователей</td></tr>
+            <tr><td>23</td><td>Простой API Relay</td><td><a href="https://jeniya.top" target="_blank">https://jeniya.top</a></td><td>🔓✌💪🎉🚀</td><td>Агрегация моделей, без ограничений, 100 ¥ тестовый кредит</td></tr>
+            <tr><td>24</td><td>CloseAI</td><td><a href="https://closeai-asia.com" target="_blank">https://closeai-asia.com</a></td><td>💰✌💪🎉🚀</td><td>Корпоративный прокси, GPT-4o и Claude 3.5, китайская поддержка</td></tr>
+            <tr><td>25</td><td>Cloud Whale AI</td><td><a href="https://api.atalk-ai.com" target="_blank">https://api.atalk-ai.com</a></td><td>🔓✌💪🎉🚀</td><td>Агрегация ChatGPT, Claude, Wenxin, купон 5 ¥</td></tr>
+            <tr><td>26</td><td>ModelBridge</td><td><a href="https://model-bridge.okeeper.com" target="_blank">https://model-bridge.okeeper.com</a></td><td>🔓✌💪🎉🚀</td><td>Бесплатный внутренний прокси, совместимый с OpenAI и китайскими моделями</td></tr>
+            <tr><td>27</td><td>UiUi API</td><td><a href="https://sg.uiuiapi.com" target="_blank">https://sg.uiuiapi.com</a></td><td>🔓✌💪🎉🚀</td><td>Поддержка Claude 4, Gemini, совместимость с форматом OpenAI</td></tr>
+            <tr><td>28</td><td>LaoZhang API Relay</td><td><a href="https://api.laozhang.ai" target="_blank">https://api.laozhang.ai</a></td><td>🔓✌💪🎉🚀</td><td>Claude 3 и GPT-4o, 20 ¥ для новых пользователей, Alipay/WeChat</td></tr>
+            <tr><td>29</td><td>Haiwhale AI Platform</td><td><a href="https://ai.atalk-ai.com" target="_blank">https://ai.atalk-ai.com</a></td><td>🔓✌💪🎉🚀</td><td>Зарегистрированная платформа, унифицированный доступ к API</td></tr>
+            <tr><td>30</td><td>One API</td><td><a href="https://one-api.ai" target="_blank">https://one-api.ai</a></td><td>🔓✌💪🎉🚀</td><td>Управление интерфейсами с открытым кодом, частное развертывание</td></tr>
+            <tr><td>31</td><td>OpenRouter</td><td><a href="https://openrouter.ai" target="_blank">https://openrouter.ai</a></td><td>🔓✌💪🎉🚀</td><td>293 модели (OpenAI, Claude, Gemini), бесплатная квота</td></tr>
+            <tr><td>32</td><td>Gemini API Proxy</td><td><a href="https://gemini-proxy.com" target="_blank">https://gemini-proxy.com</a></td><td>🔓✌🎉🚀</td><td>Модели Google Gemini, совместимость с OpenAI, бесплатная квота</td></tr>
+            <tr><td>33</td><td>DeepSeek API Aggregation</td><td><a href="https://deepseek-aggregator.com" target="_blank">https://deepseek-aggregator.com</a></td><td>🔓💪🎉🚀</td><td>Агрегация серии DeepSeek, бесплатная тестовая квота</td></tr>
+            <tr><td>34</td><td>Hugging Face Inference</td><td><a href="https://huggingface.co/inference-api" target="_blank">https://huggingface.co/inference-api</a></td><td>🔓💪🎉🚀</td><td>Модели с открытым кодом (Llama 3), бесплатный и корпоративный уровни</td></tr>
+            <tr><td>35</td><td>AI21 Labs Official</td><td><a href="https://studio.ai21.com" target="_blank">https://studio.ai21.com</a></td><td>💰✌💪🎉</td><td>Модели Jurassic-2, задачи NLP</td></tr>
+            <tr><td>36</td><td>Cohere API</td><td><a href="https://cohere.ai" target="_blank">https://cohere.ai</a></td><td>💰✌💪🎉</td><td>Генерация и классификация текста, корпоративный API</td></tr>
+            <tr><td>37</td><td>AI API Aggregator</td><td><a href="https://api.ai-aggregator.com" target="_blank">https://api.ai-aggregator.com</a></td><td>🔓✌💪🎉🚀</td><td>Агрегация моделей, унифицированный интерфейс, балансировка нагрузки</td></tr>
+            <tr><td>38</td><td>AI.LS</td><td><a href="https://ai.ls" target="_blank">https://ai.ls</a></td><td>🆓✌</td><td>Минимальный интерфейс, GPT-3.5 бесплатно анонимно</td></tr>
+            <tr><td>39</td><td>Simple API</td><td><a href="https://jeniya.top" target="_blank">https://jeniya.top</a></td><td>🔓✌💪🎉🎁</td><td>Кредит 100 ¥ при регистрации, поддержка Claude/GPT-4o</td></tr>
+            <tr><td>40</td><td>OpenAI120</td><td><a href="https://openai120.com" target="_blank">https://openai120.com</a></td><td>🔓✌🎁</td><td>$3 для новых пользователей, официальная цена</td></tr>
+            <tr><td>41</td><td>DuckAGI</td><td><a href="https://duckagi.com" target="_blank">https://duckagi.com</a></td><td>💰✌🎉🚀</td><td>Мультимодальный GPT-4o/Sora, генерация AI-изображений</td></tr>
+            <tr><td>42</td><td>Aihubmix</td><td><a href="https://aihubmix.com" target="_blank">https://aihubmix.com</a></td><td>💰🎉</td><td>Агрегация китайских моделей (Wenxin/Tongyi)</td></tr>
+            <tr><td>43</td><td>WokaAI</td><td><a href="https://wokaai.com" target="_blank">https://wokaai.com</a></td><td>✌</td><td>Двойные маршруты</td></tr>
+            <tr><td>44</td><td>azapi</td><td><a href="https://azapi.com.cn" target="_blank">https://azapi.com.cn</a></td><td>💰</td><td>Скидки для долгосрочных пользователей</td></tr>
+            <tr><td>45</td><td>ClaudeAPI</td><td><a href="https://claudeapi.io" target="_blank">https://claudeapi.io</a></td><td>💪🚀✔</td><td>Официальное партнерство Anthropic, поддержка парсинга файлов</td></tr>
+            <tr><td>46</td><td>Gala API</td><td><a href="https://galaapi.com" target="_blank">https://galaapi.com</a></td><td>🎉🚀</td><td>Выделенный высокоскоростной канал Google Gemini</td></tr>
+            <tr><td>47</td><td>Google AI Studio</td><td><a href="https://ai.google.dev" target="_blank">https://ai.google.dev</a></td><td>🆓🌎✔</td><td>Серия Gemini полностью бесплатна, требуется VPN</td></tr>
+            <tr><td>48</td><td>OpenAI Data Sharing</td><td><a href="https://platform.openai.com" target="_blank">https://platform.openai.com</a></td><td>🔓✌🌎</td><td>До 1M бесплатных токенов в день с включенной передачей данных</td></tr>
+            <tr><td>49</td><td>Mistral AI Platform</td><td><a href="https://platform.mistral.ai" target="_blank">https://platform.mistral.ai</a></td><td>🔓🎉🌎</td><td>Официальная платформа бесплатного API-тестирования (ограничение скорости)</td></tr>
+            <tr><td>50</td><td>Cohere</td><td><a href="https://cohere.com" target="_blank">https://cohere.com</a></td><td>🔓🎉🌎</td><td>Пробный ключ при регистрации, бесплатно с ограничениями скорости</td></tr>
+            <tr><td>51</td><td>ModelScope</td><td><a href="https://modelscope.cn" target="_blank">https://modelscope.cn</a></td><td>🔓🎉🚩</td><td>Агрегация DeepSeek/Qwen, бесплатные тесты и загрузка моделей</td></tr>
+            <tr><td>52</td><td>ByteDance Ark Plan</td><td><a href="https://www.volcengine.com/product/ark" target="_blank">https://www.volcengine.com/product/ark</a></td><td>🔓🎉</td><td>500K токенов в день на модель в плане сотрудничества</td></tr>
+            <tr><td>53</td><td>Zhipu BigModel</td><td><a href="https://open.bigmodel.cn" target="_blank">https://open.bigmodel.cn</a></td><td>🆓🎉</td><td>GLM-4-Flash API полностью бесплатен, контекст 128K</td></tr>
+            <tr><td>54</td><td>InternLM</td><td><a href="https://internlm.intern-ai.org.cn" target="_blank">https://internlm.intern-ai.org.cn</a></td><td>🆓🎉</td><td>Официальный бесплатный API, прямой доступ</td></tr>
+            <tr><td>55</td><td>GitHub Models</td><td><a href="https://docs.github.com/github-models" target="_blank">https://docs.github.com/github-models</a></td><td>🔓✌🎉🌎</td><td>Размещение Azure, ограниченная бесплатная квота API</td></tr>
+            <tr><td>56</td><td>OpenRouter (Free)</td><td><a href="https://openrouter.ai" target="_blank">https://openrouter.ai</a></td><td>🔓💪✌🎉🌎✔</td><td>Бесплатные модели ≤50 в день, баланс ≥$10 до 1000</td></tr>
+            <tr><td>57</td><td>Chutes</td><td><a href="https://chutes.ai" target="_blank">https://chutes.ai</a></td><td>🔓🎉</td><td>Некоторые модели 200 бесплатных вызовов в день, поддержка DeepSeek</td></tr>
+            <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>Доступен бесплатный API-ключ, совместимость с OpenAI, сверхбыстрый вывод</td></tr>
+            <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>Разработчики получают 1M бесплатных токенов в день, LLM вывод 450+ t/s</td></tr>
+            <tr><td>60</td><td>Infini-AI GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>DeepSeek R1/V3 полная версия бесплатных токенов, без пригласительного кода</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    
+    <div class="section">
+      <h2>📱 Рекомендуемые приложения</h2>
+      <details>
+        <summary>📦 Нажмите, чтобы увидеть список приложений</summary>
+        <div class="apps-grid">
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/CherryHQ/cherry-studio" target="_blank">Cherry Studio</a></h4>
+            <p>Кроссплатформенное приложение, интеграция облачных AI-сервисов и локальных моделей.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://u.tools/plugins/detail/ChatGPT.%E5%A5%BD%E5%8F%8B/" target="_blank">Плагин ChatGPT для uTools</a></h4>
+            <p>Десктоп-плагин для интеллектуального чата, поддержка нескольких моделей и сессий.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Yidadaa/ChatGPT-Next-Web" target="_blank">ChatGPT-Next-Web</a></h4>
+            <p>Открытая веб-оболочка для ChatGPT, поддержка API Key и совместной работы.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/lobehub/lobe-chat" target="_blank">LobeChat</a></h4>
+            <p>Веб-фреймворк с голосовой и визуальной поддержкой.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://botgem.com/" target="_blank">BotGem</a></h4>
+            <p>Мобильное приложение с голосовым общением и AI-друзьями.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Bin-Huang/chatbox" target="_blank">ChatBox</a></h4>
+            <p>Поддержка iOS, Android и десктопа, современный интерфейс.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/labring/FastGPT" target="_blank">FastGPT</a></h4>
+            <p>Интеграция базы знаний и рабочих процессов, корпоративное решение.</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank">AnythingLLM</a></h4>
+            <p>Локальный деплой и расширения, для пользователей, заботящихся о приватности.</p>
+          </div>
+        </div>
+      </details>
+    </div>
+    
+    <div class="section">
+      <h2>📖 Руководство по использованию</h2>
+      <ol class="usage-steps">
+        <li>🔑 <strong>Получите API Key</strong>: зарегистрируйтесь и скопируйте из личного кабинета</li>
+        <li>⚙ <strong>Настройте Endpoint</strong>: вставьте адрес API в поддерживаемое приложение</li>
+        <li>🤖 <strong>Выберите модель</strong>: в зависимости от платформы выберите Claude / GPT и др.</li>
+        <li>📊 <strong>Мониторинг использования</strong>: включите лимиты в настройках приложения</li>
+      </ol>
+    </div>
+    
+    <div class="section">
+      <h2>🙌 Руководство по вкладу</h2>
+      <p>Принимаем:</p>
+      <ul style="margin-left: 20px; margin-top: 10px;">
+        <li>✨ Добавление новых поставщиков API (стабильная работа ≥ 3 дней)</li>
+        <li>🧰 Добавление руководств (скриншоты, видео)</li>
+        <li>🧪 Скрипты верификации (авто-проверка недоступных платформ)</li>
+        <li>🌍 Мультиязычные переводы (английский, японский, корейский и др.)</li>
+      </ul>
+      <p style="margin-top: 15px;">💡 Пожалуйста, создайте Pull Request или Issue — мы оперативно рассмотрим.</p>
+    </div>
+    
+    <div class="section">
+      <h2>❌ Неактивные платформы</h2>
+      <details>
+        <summary>📛 Нажмите, чтобы увидеть недоступные платформы</summary>
+        <table style="width: 100%; margin-top: 15px;">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Название</th>
+              <th>Ссылка</th>
+              <th>Статус</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>464888</td>
+              <td><a href="https://api.464888.xyz" target="_blank">api.464888.xyz</a></td>
+              <td>❌ Недоступна</td>
+            </tr>
+          </tbody>
+        </table>
+        <p style="margin-top: 10px;">💡 Если обнаружите новую неработающую платформу, сообщите через Issue.</p>
+      </details>
+    </div>
+    
+    <div class="section">
+      <h2>⚖️ Отказ от ответственности</h2>
+      <ul style="margin-left: 20px;">
+        <li>Этот проект не хранит API Key и не предоставляет прокси или ретрансляторы.</li>
+        <li>Платформы в списке — публичные. Использование на ваш страх и риск.</li>
+        <li>Автор не несет ответственности за возможные убытки или ущерб.</li>
+      </ul>
+    </div>
+    
+    <div class="section">
+      <h2>🙏 Особая благодарность</h2>
+      <p>Огромная благодарность <strong>zenmux</strong> за поддержку платформы API!<br>
+      <a href="https://zenmux.ai/invite/U1QU1H" target="_blank">Зарегистрируйтесь и используйте пригласительный код</a></p>
+      
+      <p style="margin-top: 15px;">Огромная благодарность <strong>chat01</strong> за поддержку сервиса!<br>
+      <a href="https://chat01.ai/?ref=j45ikbTa" target="_blank">Посетите chat01 и используйте реферальный код</a></p>
+      
+      <p style="margin-top: 15px;">
+        <a href="https://dartnode.com" target="_blank">
+          <img src="https://dartnode.com/branding/DN-Open-Source-sm.png" alt="Powered by DartNode">
+        </a>
+      </p>
+    </div>
+    
+    <footer>
+      <p style="margin-bottom: 15px;">
+        <a href="https://star-history.com/#TechnologyStar/Openai-Claude-Deepseek-API-provider&Date" target="_blank">
+          <img src="https://api.star-history.com/svg?repos=TechnologyStar/Openai-Claude-Deepseek-API-provider&type=Date" alt="Star History" style="max-width: 100%; height: auto;">
+        </a>
+      </p>
+      <p>Сделано с ❤️ by <a href="https://github.com/TechnologyStar" target="_blank">TechnologyStar</a></p>
+      <p style="margin-top: 10px; font-size: 0.9em; color: #666;">
+        <a href="https://github.com/TechnologyStar/Openai-Claude-Deepseek-API-provider" target="_blank">Репозиторий GitHub</a>
+      </p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/website/index.zh-CN.html
+++ b/website/index.zh-CN.html
@@ -1,0 +1,590 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>🌐 OpenAI / Claude / DeepSeek API Provider - 第三方API提供商目录</title>
+  <meta name="description" content="精选的第三方平台列表，提供 OpenAI / Claude / DeepSeek API，供学习、研究和非商业使用。">
+  <meta name="keywords" content="OpenAI, Claude, DeepSeek, API, 第三方, 免费, 人工智能, AI">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
+    }
+    
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    
+    header {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      margin-bottom: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+      text-align: center;
+    }
+    
+    h1 {
+      font-size: 2.5em;
+      margin-bottom: 15px;
+      color: #667eea;
+      text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    
+    .subtitle {
+      font-size: 1.2em;
+      color: #666;
+      margin-bottom: 20px;
+    }
+    
+    .badges {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin: 20px 0;
+    }
+    
+    .badges img {
+      height: 20px;
+    }
+    
+    .lang-switcher {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      margin-top: 20px;
+      flex-wrap: wrap;
+    }
+    
+    .lang-btn {
+      padding: 8px 16px;
+      background: #667eea;
+      color: white;
+      text-decoration: none;
+      border-radius: 20px;
+      font-size: 14px;
+      transition: all 0.3s;
+    }
+    
+    .lang-btn:hover {
+      background: #764ba2;
+      transform: translateY(-2px);
+      box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+    }
+    
+    .lang-btn.active {
+      background: #764ba2;
+    }
+    
+    .notice {
+      background: #fff3cd;
+      border-left: 4px solid #ffc107;
+      padding: 20px;
+      border-radius: 10px;
+      margin-bottom: 30px;
+    }
+    
+    .section {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      margin-bottom: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    }
+    
+    h2 {
+      font-size: 2em;
+      margin-bottom: 20px;
+      color: #667eea;
+      border-bottom: 3px solid #667eea;
+      padding-bottom: 10px;
+    }
+    
+    h3 {
+      font-size: 1.5em;
+      margin: 20px 0 10px;
+      color: #764ba2;
+    }
+    
+    .tags-legend {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 10px;
+      margin: 20px 0;
+    }
+    
+    .tag-item {
+      padding: 10px;
+      background: #f8f9fa;
+      border-radius: 8px;
+      border-left: 3px solid #667eea;
+    }
+    
+    .providers-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 20px 0;
+      overflow-x: auto;
+      display: block;
+    }
+    
+    .providers-table table {
+      width: 100%;
+      min-width: 800px;
+    }
+    
+    .providers-table th,
+    .providers-table td {
+      padding: 12px;
+      text-align: left;
+      border-bottom: 1px solid #e0e0e0;
+    }
+    
+    .providers-table th {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      font-weight: 600;
+      position: sticky;
+      top: 0;
+    }
+    
+    .providers-table tr:hover {
+      background: #f5f5f5;
+    }
+    
+    .providers-table a {
+      color: #667eea;
+      text-decoration: none;
+      font-weight: 500;
+    }
+    
+    .providers-table a:hover {
+      text-decoration: underline;
+    }
+    
+    .apps-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 20px;
+      margin: 20px 0;
+    }
+    
+    .app-card {
+      padding: 20px;
+      background: #f8f9fa;
+      border-radius: 10px;
+      border-left: 4px solid #667eea;
+      transition: all 0.3s;
+    }
+    
+    .app-card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+    }
+    
+    .app-card h4 {
+      color: #667eea;
+      margin-bottom: 10px;
+    }
+    
+    .usage-steps {
+      counter-reset: step;
+      list-style: none;
+      padding: 0;
+    }
+    
+    .usage-steps li {
+      counter-increment: step;
+      padding: 15px;
+      margin: 10px 0;
+      background: #f8f9fa;
+      border-radius: 10px;
+      position: relative;
+      padding-left: 60px;
+    }
+    
+    .usage-steps li::before {
+      content: counter(step);
+      position: absolute;
+      left: 15px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      width: 35px;
+      height: 35px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+    }
+    
+    footer {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border-radius: 15px;
+      padding: 30px;
+      text-align: center;
+      margin-top: 30px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    }
+    
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+      margin: 20px 0;
+    }
+    
+    .stat-card {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 25px;
+      border-radius: 10px;
+      text-align: center;
+    }
+    
+    .stat-number {
+      font-size: 3em;
+      font-weight: bold;
+      margin-bottom: 5px;
+    }
+    
+    .stat-label {
+      font-size: 1.1em;
+      opacity: 0.9;
+    }
+    
+    @media (max-width: 768px) {
+      h1 {
+        font-size: 1.8em;
+      }
+      
+      .providers-table {
+        font-size: 14px;
+      }
+      
+      .container {
+        padding: 10px;
+      }
+    }
+    
+    details {
+      margin: 20px 0;
+    }
+    
+    summary {
+      cursor: pointer;
+      padding: 15px;
+      background: #f8f9fa;
+      border-radius: 10px;
+      font-weight: 600;
+      color: #667eea;
+      user-select: none;
+    }
+    
+    summary:hover {
+      background: #e9ecef;
+    }
+    
+    details[open] summary {
+      margin-bottom: 15px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🌐 OpenAI / Claude / DeepSeek API Provider</h1>
+      <p class="subtitle">精选的第三方平台列表，提供 OpenAI / Claude / DeepSeek API</p>
+      <p class="subtitle">供学习、研究和非商业使用</p>
+      
+      <div class="badges">
+        <img src="https://img.shields.io/github/last-commit/TechnologyStar/Openai-Claude-Deepseek-API-provider" alt="Last Commit">
+        <img src="https://img.shields.io/github/license/TechnologyStar/Openai-Claude-Deepseek-API-provider" alt="License">
+      </div>
+      
+      <div class="lang-switcher">
+        <a href="index.zh-CN.html" class="lang-btn active">🇨🇳 中文</a>
+        <a href="index.en.html" class="lang-btn">🇬🇧 English</a>
+        <a href="index.ru.html" class="lang-btn">🇷🇺 Русский</a>
+        <a href="index.fr.html" class="lang-btn">🇫🇷 Français</a>
+      </div>
+    </header>
+    
+    <div class="notice section">
+      <h3>⚠️ 使用说明</h3>
+      <p><strong>本项目为免费公益项目，严格禁止任何违法用途。</strong></p>
+      <p><strong>本项目不会收录一些AI论坛内部的站点，如有误收录，请联系删除，在评估后将会对部分误收录网站进行赔偿。</strong></p>
+      <ul style="margin-top: 10px; margin-left: 20px;">
+        <li>遵守 <a href="https://openai.com/policies/terms-of-use" target="_blank">OpenAI 使用条款</a></li>
+        <li>遵守 <a href="http://www.cac.gov.cn/2023-07/13/c_1690898327029107.htm" target="_blank">《生成式人工智能服务管理暂行办法》</a>，<strong>请勿对中国公众提供未经备案的生成式AI服务</strong></li>
+      </ul>
+    </div>
+    
+    <div class="section">
+      <h2>🚀 项目简介</h2>
+      <p>📌 收录并验证来自互联网的第三方 API 提供平台（部分免费）</p>
+      <p>🔧 免注册 / 一键接入 / 支持多模型（OpenAI、Claude、DeepSeek 等）</p>
+      <p>🔒 所有网站仅作收录展示，<strong>请勿输入个人敏感信息</strong></p>
+      <p style="margin-top: 15px;">💡 如果觉得项目有帮助，欢迎 Star 🌟</p>
+    </div>
+    
+    <div class="section">
+      <h2>📊 统计数据</h2>
+      <div class="stats">
+        <div class="stat-card">
+          <div class="stat-number">60+</div>
+          <div class="stat-label">API 提供商</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">20+</div>
+          <div class="stat-label">免费平台</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-number">8</div>
+          <div class="stat-label">推荐应用</div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="section">
+      <h2>🎁 特色标签说明</h2>
+      <div class="tags-legend">
+        <div class="tag-item">🆓 完全免费</div>
+        <div class="tag-item">🔓 有免费额度</div>
+        <div class="tag-item">💰 需要充值</div>
+        <div class="tag-item">💪 Claude 最新支持</div>
+        <div class="tag-item">✌ OpenAI 最新支持</div>
+        <div class="tag-item">🎉 其他模型支持（如 DeepSeek）</div>
+        <div class="tag-item">🌎 需要国际网络</div>
+        <div class="tag-item">🎁 充值赠送额度优惠</div>
+        <div class="tag-item">🚀 支持高并发</div>
+        <div class="tag-item">😆 每日签到领余额</div>
+        <div class="tag-item">🚩 已备案平台</div>
+        <div class="tag-item">✔ 已验证真实性</div>
+      </div>
+    </div>
+    
+    <div class="section">
+      <h2>🌐 第三方 API 提供方列表</h2>
+      <div class="providers-table">
+        <table>
+          <thead>
+            <tr>
+              <th>序号</th>
+              <th>网站</th>
+              <th>链接</th>
+              <th>标签</th>
+              <th>备注</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>chat01（推荐，含邀请码）</td><td><a href="https://chat01.ai/?ref=j45ikbTa" target="_blank">https://chat01.ai</a></td><td>🔓✌🎁💰✔</td><td>支持Pro，解决降智问题，每天免费2积分，聊天+API同站</td></tr>
+            <tr><td>2</td><td>硅基流动（企业级）</td><td><a href="https://cloud.siliconflow.cn/i/ZKV30bdG" target="_blank">https://cloud.siliconflow.cn</a></td><td>🔓🎉🚀🚩✔</td><td>华为云昇腾服务，注册送14元</td></tr>
+            <tr><td>3</td><td>zenmux(推荐，含免费gemini3及画图)</td><td><a href="https://zenmux.ai/invite/U1QU1H" target="_blank">https://zenmux.ai</a></td><td>🔓✌🎁💰</td><td>免费gemini3pro,全球首个支持赔付的大模型聚合</td></tr>
+            <tr><td>4</td><td>PoloAPI</td><td><a href="https://poloai.top" target="_blank">https://poloai.top</a></td><td>🔓💪✌🎉🎁💰</td><td>新用户注册送0.3 $额度，聚合Claude/Grok/OpenAI等多模型</td></tr>
+            <tr><td>5</td><td>OAIPro</td><td><a href="https://api.oaipro.com" target="_blank">https://api.oaipro.com</a></td><td>💰✌💪</td><td>官方费率，稳定直连，支持OpenAI与Claude接口</td></tr>
+            <tr><td>6</td><td>VoAPI</td><td><a href="https://demo.voapi.top" target="_blank">https://demo.voapi.top</a></td><td>🆓😆💪✌</td><td>【全公益网站】余额每日清零</td></tr>
+            <tr><td>7</td><td>inscopilot(推荐)</td><td><a href="https://instcopilot-api.com/register?aff=Q2Z0" target="_blank">https://instcopilot-api.com</a></td><td>✌🎉😆🚀</td><td>赠$5，稳定便宜，支持cc</td></tr>
+            <tr><td>8</td><td>V3 API（混合版）</td><td><a href="https://api.v3.cm" target="_blank">https://api.v3.cm</a></td><td>🚀🔓💪🎁🎉✌</td><td>赠$0.2，高并发，3折充值，超多模型</td></tr>
+            <tr><td>9</td><td>V3 API（官转版）</td><td><a href="https://gf.gpt.ge" target="_blank">https://gf.gpt.ge</a></td><td>🚀🌹🔓💪</td><td>赠$0.2，高并发，6折充值</td></tr>
+            <tr><td>10</td><td>openai-hk</td><td><a href="https://openai-hk.com" target="_blank">https://openai-hk.com</a></td><td>🆓🔓🎉✌💪🚀</td><td>赠1元，超高并发，含GPT-3.5公益版</td></tr>
+            <tr><td>11</td><td>ChatGPT API 水龙头</td><td><a href="https://faucet.openkey.cloud" target="_blank">https://faucet.openkey.cloud</a></td><td>🆓</td><td>免费$1额度，3天有效期</td></tr>
+            <tr><td>12</td><td>公益免费的ChatGPT API</td><td><a href="https://github.com/popjane/free_chatgpt_api" target="_blank">GitHub</a></td><td>🆓</td><td>公益免费</td></tr>
+            <tr><td>13</td><td>GPT-API-free</td><td><a href="https://github.com/chuyuewei/ChatGPT-API" target="_blank">GitHub</a></td><td>🆓💪</td><td>支持GPT-4，每天3次</td></tr>
+            <tr><td>14</td><td>openkey</td><td><a href="https://openkey.cloud" target="_blank">https://openkey.cloud</a></td><td>🔓💪✌🚀</td><td>赠$0.2，支持多并发</td></tr>
+            <tr><td>15</td><td>gptgod.online</td><td><a href="https://gptgod.online" target="_blank">https://gptgod.online</a></td><td>💪✌🎁💰🎉😆</td><td>按次计费，积分额度</td></tr>
+            <tr><td>16</td><td>m3.ckit.gold</td><td><a href="https://m3.ckit.gold" target="_blank">https://m3.ckit.gold</a></td><td>💰💪✌</td><td>3元/刀，注册送$0.1</td></tr>
+            <tr><td>17</td><td>iaicnn</td><td><a href="https://aicnn.cn" target="_blank">https://aicnn.cn</a></td><td>💪✌🎁💰🎉</td><td>老用户支持api，目前已迁移</td></tr>
+            <tr><td>18</td><td>goapi.gptnb.ai</td><td><a href="https://goapi.gptnb.ai" target="_blank">https://goapi.gptnb.ai</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>19</td><td>api.aigc369.com</td><td><a href="https://api.aigc369.com/pricing" target="_blank">https://api.aigc369.com</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>20</td><td>api.mjdjourney.cn</td><td><a href="https://api.mjdjourney.cn" target="_blank">https://api.mjdjourney.cn</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>21</td><td>api.bltcy.ai</td><td><a href="https://api.bltcy.ai" target="_blank">https://api.bltcy.ai</a></td><td>💪✌🎁💰🎉</td><td></td></tr>
+            <tr><td>22</td><td>4Z API 中转站</td><td><a href="https://zzzzapi.com" target="_blank">https://zzzzapi.com</a></td><td>🔓✌💪🎉🚀</td><td>支持GPT-4o、Claude 3.5，新用户赠0.2额度。</td></tr>
+            <tr><td>23</td><td>简易API中转站</td><td><a href="https://jeniya.top" target="_blank">https://jeniya.top</a></td><td>🔓✌💪🎉🚀</td><td>聚合多模型，国内直连无限制，注册送100元测试额度。</td></tr>
+            <tr><td>24</td><td>CloseAI</td><td><a href="https://closeai-asia.com" target="_blank">https://closeai-asia.com</a></td><td>💰✌💪🎉🚀</td><td>企业级代理，支持GPT-4o、Claude 3.5，提供中文技术支持。</td></tr>
+            <tr><td>25</td><td>云鲸AI</td><td><a href="https://api.atalk-ai.com" target="_blank">https://api.atalk-ai.com</a></td><td>🔓✌💪🎉🚀</td><td>聚合ChatGPT、Claude、文心一言，注册赠5元体验券。</td></tr>
+            <tr><td>26</td><td>ModelBridge</td><td><a href="https://model-bridge.okeeper.com" target="_blank">https://model-bridge.okeeper.com</a></td><td>🔓✌💪🎉🚀</td><td>国内免费代理，兼容OpenAI接口和国产模型（如文心一言）。</td></tr>
+            <tr><td>27</td><td>UiUi API</td><td><a href="https://sg.uiuiapi.com" target="_blank">https://sg.uiuiapi.com</a></td><td>🔓✌💪🎉🚀</td><td>支持Claude 4、Gemini等模型，兼容OpenAI接口格式。</td></tr>
+            <tr><td>28</td><td>老张API中转服务</td><td><a href="https://api.laozhang.ai" target="_blank">https://api.laozhang.ai</a></td><td>🔓✌💪🎉🚀</td><td>支持Claude 3和GPT-4o，新用户赠20元额度，支持支付宝/微信支付。</td></tr>
+            <tr><td>29</td><td>海鲸AI聚合平台</td><td><a href="https://ai.atalk-ai.com" target="_blank">https://ai.atalk-ai.com</a></td><td>🔓✌💪🎉🚀</td><td>国内备案平台，支持多模型统一API接入。</td></tr>
+            <tr><td>30</td><td>One API</td><td><a href="https://one-api.ai" target="_blank">https://one-api.ai</a></td><td>🔓✌💪🎉🚀</td><td>开源接口管理系统，支持多模型分发和私有化部署。</td></tr>
+            <tr><td>31</td><td>OpenRouter</td><td><a href="https://openrouter.ai" target="_blank">https://openrouter.ai</a></td><td>🔓✌💪🎉🚀</td><td>支持293个模型（含OpenAI、Claude、Gemini），提供免费额度。</td></tr>
+            <tr><td>32</td><td>Gemini API代理</td><td><a href="https://gemini-proxy.com" target="_blank">https://gemini-proxy.com</a></td><td>🔓✌🎉🚀</td><td>支持Google Gemini模型，兼容OpenAI接口，提供免费额度。</td></tr>
+            <tr><td>33</td><td>DeepSeek API聚合</td><td><a href="https://deepseek-aggregator.com" target="_blank">https://deepseek-aggregator.com</a></td><td>🔓💪🎉🚀</td><td>聚合DeepSeek系列模型，提供免费测试额度。</td></tr>
+            <tr><td>34</td><td>Hugging Face模型代理</td><td><a href="https://huggingface.co/inference-api" target="_blank">https://huggingface.co/inference-api</a></td><td>🔓💪🎉🚀</td><td>支持开源模型（如Llama 3），提供免费额度和企业级服务。</td></tr>
+            <tr><td>35</td><td>AI21 Labs官方代理</td><td><a href="https://studio.ai21.com" target="_blank">https://studio.ai21.com</a></td><td>💰✌💪🎉</td><td>支持Jurassic-2模型，适合自然语言处理任务。</td></tr>
+            <tr><td>36</td><td>Cohere API代理</td><td><a href="https://cohere.ai" target="_blank">https://cohere.ai</a></td><td>💰✌💪🎉</td><td>支持文本生成和分类模型，提供企业级API。</td></tr>
+            <tr><td>37</td><td>AI API聚合平台</td><td><a href="https://api.ai-aggregator.com" target="_blank">https://api.ai-aggregator.com</a></td><td>🔓✌💪🎉🚀</td><td>聚合多模型，提供统一接口和负载均衡。</td></tr>
+            <tr><td>38</td><td>AI.LS</td><td><a href="https://ai.ls" target="_blank">https://ai.ls</a></td><td>🆓✌</td><td>极简接口，GPT-3.5免费匿名使用</td></tr>
+            <tr><td>39</td><td>简易API</td><td><a href="https://jeniya.top" target="_blank">https://jeniya.top</a></td><td>🔓✌💪🎉🎁</td><td>注册送¥100额度，支持Claude/GPT-4o多模型</td></tr>
+            <tr><td>40</td><td>OpenAI120</td><td><a href="https://openai120.com" target="_blank">https://openai120.com</a></td><td>🔓✌🎁</td><td>新用户送$3额度，单价同官方</td></tr>
+            <tr><td>41</td><td>DuckAGI</td><td><a href="https://duckagi.com" target="_blank">https://duckagi.com</a></td><td>💰✌🎉🚀</td><td>多模态支持GPT-4o/Sora，适合AI绘图</td></tr>
+            <tr><td>42</td><td>Aihubmix</td><td><a href="https://aihubmix.com" target="_blank">https://aihubmix.com</a></td><td>💰🎉</td><td>国产模型聚合（文心一言/通义千问）</td></tr>
+            <tr><td>43</td><td>WokaAI</td><td><a href="https://wokaai.com" target="_blank">https://wokaai.com</a></td><td>✌</td><td>双线路</td></tr>
+            <tr><td>44</td><td>azapi</td><td><a href="https://azapi.com.cn" target="_blank">https://azapi.com.cn</a></td><td>💰</td><td>长期使用优惠</td></tr>
+            <tr><td>45</td><td>ClaudeAPI</td><td><a href="https://claudeapi.io" target="_blank">https://claudeapi.io</a></td><td>💪🚀✔</td><td>Anthropic官方合作，支持文件解析</td></tr>
+            <tr><td>46</td><td>Gala API</td><td><a href="https://galaapi.com" target="_blank">https://galaapi.com</a></td><td>🎉🚀</td><td>谷歌Gemini专用高速通道</td></tr>
+            <tr><td>47</td><td>Google AI Studio</td><td><a href="https://ai.google.dev" target="_blank">https://ai.google.dev</a></td><td>🆓🌎✔</td><td>Gemini系列完全免费，需科学上网访问</td></tr>
+            <tr><td>48</td><td>OpenAI 数据共享计划</td><td><a href="https://platform.openai.com" target="_blank">https://platform.openai.com</a></td><td>🔓✌🌎</td><td>开启数据共享后每日最高获1 M免费tokens</td></tr>
+            <tr><td>49</td><td>Mistral AI La Plateforme</td><td><a href="https://platform.mistral.ai" target="_blank">https://platform.mistral.ai</a></td><td>🔓🎉🌎</td><td>官方平台提供免费API试用额度（受限速率）</td></tr>
+            <tr><td>50</td><td>Cohere</td><td><a href="https://cohere.com" target="_blank">https://cohere.com</a></td><td>🔓🎉🌎</td><td>注册可获Trial Key，免费调用但有速率限制</td></tr>
+            <tr><td>51</td><td>魔搭 ModelScope</td><td><a href="https://modelscope.cn" target="_blank">https://modelscope.cn</a></td><td>🔓🎉🚩</td><td>聚合DeepSeek/Qwen等模型，模型试用与下载免费</td></tr>
+            <tr><td>52</td><td>字节 方舟协作奖励计划</td><td><a href="https://www.volcengine.com/product/ark" target="_blank">https://www.volcengine.com/product/ark</a></td><td>🔓🎉</td><td>参与计划单模型每天送50万Tokens</td></tr>
+            <tr><td>53</td><td>智谱 BigModel</td><td><a href="https://open.bigmodel.cn" target="_blank">https://open.bigmodel.cn</a></td><td>🆓🎉</td><td>GLM-4-Flash API完全免费，支持128K上下文</td></tr>
+            <tr><td>54</td><td>书生 InternLM</td><td><a href="https://internlm.intern-ai.org.cn" target="_blank">https://internlm.intern-ai.org.cn</a></td><td>🆓🎉</td><td>官方开放免费API，可直接调用</td></tr>
+            <tr><td>55</td><td>GitHub Models</td><td><a href="https://docs.github.com/github-models" target="_blank">https://docs.github.com/github-models</a></td><td>🔓✌🎉🌎</td><td>Azure托管，提供受限免费API配额</td></tr>
+            <tr><td>56</td><td>OpenRouter（免费版）</td><td><a href="https://openrouter.ai" target="_blank">https://openrouter.ai</a></td><td>🔓💪✌🎉🌎✔</td><td>免费模型每日≤50次，余额≥10 $可升至1000次</td></tr>
+            <tr><td>57</td><td>Chutes</td><td><a href="https://chutes.ai" target="_blank">https://chutes.ai</a></td><td>🔓🎉</td><td>部分模型每日200条免费额度，支持DeepSeek等</td></tr>
+            <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>可申请免费API Key，OpenAI兼容端点，推理速度极快</td></tr>
+            <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>开发者每日享1 M免费tokens，LLM推理可达450 t/s+</td></tr>
+            <tr><td>60</td><td>无问芯穹 GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>DeepSeek R1/V3满血版免费Token，无需邀请码</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    
+    <div class="section">
+      <h2>📱 推荐应用支持</h2>
+      <details>
+        <summary>📦 点击展开查看兼容应用列表</summary>
+        <div class="apps-grid">
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/CherryHQ/cherry-studio" target="_blank">Cherry Studio</a></h4>
+            <p>跨平台桌面端 + 移动端，集成主流 AI 云服务 + 本地模型。</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://u.tools/plugins/detail/ChatGPT.%E5%A5%BD%E5%8F%8B/" target="_blank">ChatGPT 好友插件 (uTools)</a></h4>
+            <p>桌面端智能聊天插件，支持角色设定、多模型、多会话管理。</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Yidadaa/ChatGPT-Next-Web" target="_blank">ChatGPT-Next-Web</a></h4>
+            <p>开源网页端 ChatGPT 前端，支持 API Key 与多用户协作。</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/lobehub/lobe-chat" target="_blank">LobeChat</a></h4>
+            <p>支持视觉、语音交互和多模型切换，网页端 AI 会话框架。</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://botgem.com/" target="_blank">BotGem</a></h4>
+            <p>移动端优先设计，支持语音交流与 AI 好友系统。</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Bin-Huang/chatbox" target="_blank">ChatBox</a></h4>
+            <p>支持 iOS、Android 和桌面端，界面现代，功能完整。</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/labring/FastGPT" target="_blank">FastGPT</a></h4>
+            <p>知识库 + 工作流集成，企业内训/客服场景首选。</p>
+          </div>
+          <div class="app-card">
+            <h4>✅ <a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank">AnythingLLM</a></h4>
+            <p>支持本地部署与插件扩展，适合对数据隐私有要求的用户。</p>
+          </div>
+        </div>
+      </details>
+    </div>
+    
+    <div class="section">
+      <h2>📖 使用指南</h2>
+      <ol class="usage-steps">
+        <li>🔑 <strong>获取 API Key</strong>：注册平台后，在用户中心复制</li>
+        <li>⚙ <strong>配置 Endpoint</strong>：填写 API 地址到支持应用中</li>
+        <li>🤖 <strong>选择模型</strong>：根据平台支持情况切换不同模型</li>
+        <li>📊 <strong>用量监控</strong>：推荐使用客户端自带用量限制功能</li>
+      </ol>
+    </div>
+    
+    <div class="section">
+      <h2>🙌 贡献指南</h2>
+      <p>我们欢迎以下贡献方式：</p>
+      <ul style="margin-left: 20px; margin-top: 10px;">
+        <li>✨ 添加新 API 提供商（需稳定运行 ≥ 3 天）</li>
+        <li>🧰 补充使用教程（包括配置截图、录屏）</li>
+        <li>🧪 开发验证脚本（自动检测失效平台）</li>
+        <li>🌍 多语言翻译（如：英文、日文、韩文等）</li>
+      </ul>
+      <p style="margin-top: 15px;">💡 请提交 Pull Request 或 Issue，我们将尽快处理！</p>
+    </div>
+    
+    <div class="section">
+      <h2>❌ 失效平台列表</h2>
+      <details>
+        <summary>📛 点击展开查看失效平台</summary>
+        <table style="width: 100%; margin-top: 15px;">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>名称</th>
+              <th>链接</th>
+              <th>状态</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>464888</td>
+              <td><a href="https://api.464888.xyz" target="_blank">api.464888.xyz</a></td>
+              <td>❌ 无法访问</td>
+            </tr>
+          </tbody>
+        </table>
+        <p style="margin-top: 10px;">💡 如发现新失效平台，欢迎通过 Issue 提交！</p>
+      </details>
+    </div>
+    
+    <div class="section">
+      <h2>⚖️ 法律免责声明</h2>
+      <ul style="margin-left: 20px;">
+        <li>本项目不存储任何 API Key，也不提供代理或转发服务。</li>
+        <li>所有平台来源于互联网，使用风险请自行评估。</li>
+        <li>若因使用第三方服务造成损失，作者不承担任何法律责任。</li>
+      </ul>
+    </div>
+    
+    <div class="section">
+      <h2>🙏 特别鸣谢</h2>
+      <p>非常感谢 <strong>zenmux</strong> 提供 API 平台支持！<br>
+      <a href="https://zenmux.ai/invite/U1QU1H" target="_blank">立即注册并使用优惠码</a></p>
+      
+      <p style="margin-top: 15px;">非常感谢 <strong>chat01</strong> 提供服务支持！<br>
+      <a href="https://chat01.ai/?ref=j45ikbTa" target="_blank">访问 chat01 并使用优惠码</a></p>
+      
+      <p style="margin-top: 15px;">
+        <a href="https://dartnode.com" target="_blank">
+          <img src="https://dartnode.com/branding/DN-Open-Source-sm.png" alt="Powered by DartNode">
+        </a>
+      </p>
+    </div>
+    
+    <footer>
+      <p style="margin-bottom: 15px;">
+        <a href="https://star-history.com/#TechnologyStar/Openai-Claude-Deepseek-API-provider&Date" target="_blank">
+          <img src="https://api.star-history.com/svg?repos=TechnologyStar/Openai-Claude-Deepseek-API-provider&type=Date" alt="Star History" style="max-width: 100%; height: auto;">
+        </a>
+      </p>
+      <p>Made with ❤️ by <a href="https://github.com/TechnologyStar" target="_blank">TechnologyStar</a></p>
+      <p style="margin-top: 10px; font-size: 0.9em; color: #666;">
+        <a href="https://github.com/TechnologyStar/Openai-Claude-Deepseek-API-provider" target="_blank">GitHub 仓库</a>
+      </p>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### Summary
Convert the website from a React-based implementation to static HTML pages in multiple languages, using Chinese as the base. Adds per-language static pages and a language-redirect index, plus documentation updates.

### Details
- Added static pages: index.zh-CN.html, index.en.html, index.ru.html, index.fr.html, and index.html (redirects to appropriate language).
- Updated website/README-HTML.md with overview and usage notes for the static HTML pages.
- Added website/.gitignore to ignore Node modules, builds, and common noise.
- Documented changes in website/README-HTML.md and included migration notes.
- Left React app intact; HTML pages serve as a static alternative for quick viewing and deployment.
