### PR TITLE
docs: add AI Router to provider lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@
 <tr><td>100</td><td>VimsAI API 聚合平台</td><td><a href="https://www.vimsai.com" target="_blank">https://www.vimsai.com</a></td><td>💰🎉✨✌💪</td><td>兼容 OpenAI 标准的全球 AI 模型接入平台，900+ 模型。</td></tr>
 <tr><td>101</td><td>xcode</td><td><a href="https://xcode.best/" target="_blank">https://xcode.best/</a></td><td></td><td>claudecode专用，多渠道支持</td></tr>
 <tr><td>102</td><td>skapi</td><td><a href="https://jk.skcdn.cn/" target="_blank">https://jk.skcdn.cn/</a></td><td></td><td>支持claudecode,价额便宜</td></tr>
+<tr><td>103</td><td>AI Router</td><td><a href="https://ai-router.dev/cn" target="_blank">https://ai-router.dev/cn</a></td><td>🔓🎁😆💰</td><td>OpenAI 兼容 API 中转；注册直接解锁 5U，最多 15U 在符合条件的充值后按 1:1 解锁；每日签到 1 USD + 昨日消费额 2%。非 OpenAI 官方服务。</td></tr>
 </tbody></table>
 
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@
 <tr><td>100</td><td>VimsAI API 聚合平台</td><td><a href="https://www.vimsai.com" target="_blank">https://www.vimsai.com</a></td><td>💰🎉✨✌💪</td><td>兼容 OpenAI 标准的全球 AI 模型接入平台，900+ 模型。</td></tr>
 <tr><td>101</td><td>xcode</td><td><a href="https://xcode.best/" target="_blank">https://xcode.best/</a></td><td></td><td>claudecode专用，多渠道支持</td></tr>
 <tr><td>102</td><td>skapi</td><td><a href="https://jk.skcdn.cn/" target="_blank">https://jk.skcdn.cn/</a></td><td></td><td>支持claudecode,价额便宜</td></tr>
-<tr><td>103</td><td>AI Router</td><td><a href="https://ai-router.dev/cn" target="_blank">https://ai-router.dev/cn</a></td><td>🔓🎁😆💰</td><td>OpenAI 兼容 API 中转；注册直接解锁 5U，最多 15U 在符合条件的充值后按 1:1 解锁；每日签到 1 USD + 昨日消费额 2%。非 OpenAI 官方服务。</td></tr>
+<tr><td>103</td><td>AI Router</td><td><a href="https://ai-router.dev/cn" target="_blank">https://ai-router.dev/cn</a></td><td></td><td>独立运营的 OpenAI 兼容 API 中转；通过个人 API Key 使用并查看用量，当前模型及可用性请以 <code>/v1/models</code> 和站内说明为准。非 OpenAI 官方服务。</td></tr>
 </tbody></table>
 
 

--- a/en.md
+++ b/en.md
@@ -161,7 +161,7 @@
     <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>Apply for a free API key, OpenAI-compatible endpoints with extreme speed</td></tr>
     <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>1M free tokens per day and up to 450+ tok/s inference throughput</td></tr>
     <tr><td>60</td><td>Infini GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>DeepSeek R1/V3 full-power tokens are free—no invite code required</td></tr>
-    <tr><td>61</td><td>AI Router</td><td><a href="https://ai-router.dev" target="_blank">https://ai-router.dev</a></td><td>🔓🎁😆💰</td><td>OpenAI-compatible API relay; 5U after signup, up to 15U unlocked 1:1 with eligible top-ups, and daily check-in rewards of $1 plus 2% of the previous day's spend. Not an official OpenAI service.</td></tr>
+    <tr><td>61</td><td>AI Router</td><td><a href="https://ai-router.dev" target="_blank">https://ai-router.dev</a></td><td></td><td>Independent OpenAI-compatible API relay. Use a personal API key and review usage; query <code>/v1/models</code> and the site for current availability. Not an official OpenAI service.</td></tr>
   </tbody>
 </table>
 

--- a/en.md
+++ b/en.md
@@ -161,6 +161,7 @@
     <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>Apply for a free API key, OpenAI-compatible endpoints with extreme speed</td></tr>
     <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>1M free tokens per day and up to 450+ tok/s inference throughput</td></tr>
     <tr><td>60</td><td>Infini GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>DeepSeek R1/V3 full-power tokens are free—no invite code required</td></tr>
+    <tr><td>61</td><td>AI Router</td><td><a href="https://ai-router.dev" target="_blank">https://ai-router.dev</a></td><td>🔓🎁😆💰</td><td>OpenAI-compatible API relay; 5U after signup, up to 15U unlocked 1:1 with eligible top-ups, and daily check-in rewards of $1 plus 2% of the previous day's spend. Not an official OpenAI service.</td></tr>
   </tbody>
 </table>
 

--- a/fr.md
+++ b/fr.md
@@ -161,6 +161,7 @@
     <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>Demandez une clé API gratuite, points de terminaison compatibles OpenAI avec vitesse extrême</td></tr>
     <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>1M de tokens gratuits par jour et débit d'inférence jusqu'à 450+ tok/s</td></tr>
     <tr><td>60</td><td>Infini GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>Les tokens DeepSeek R1/V3 pleine puissance sont gratuits—aucun code d'invitation requis</td></tr>
+    <tr><td>61</td><td>AI Router</td><td><a href="https://ai-router.dev/fr" target="_blank">https://ai-router.dev/fr</a></td><td>🔓🎁😆💰</td><td>Relais API compatible OpenAI ; 5U à l’inscription, jusqu’à 15U débloqués 1:1 par des recharges éligibles ; check-in quotidien : 1 $ + 2 % des dépenses de la veille. Service non officiel d’OpenAI.</td></tr>
   </tbody>
 </table>
 

--- a/fr.md
+++ b/fr.md
@@ -161,7 +161,7 @@
     <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>Demandez une clé API gratuite, points de terminaison compatibles OpenAI avec vitesse extrême</td></tr>
     <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>1M de tokens gratuits par jour et débit d'inférence jusqu'à 450+ tok/s</td></tr>
     <tr><td>60</td><td>Infini GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>Les tokens DeepSeek R1/V3 pleine puissance sont gratuits—aucun code d'invitation requis</td></tr>
-    <tr><td>61</td><td>AI Router</td><td><a href="https://ai-router.dev/fr" target="_blank">https://ai-router.dev/fr</a></td><td>🔓🎁😆💰</td><td>Relais API compatible OpenAI ; 5U à l’inscription, jusqu’à 15U débloqués 1:1 par des recharges éligibles ; check-in quotidien : 1 $ + 2 % des dépenses de la veille. Service non officiel d’OpenAI.</td></tr>
+    <tr><td>61</td><td>AI Router</td><td><a href="https://ai-router.dev/fr" target="_blank">https://ai-router.dev/fr</a></td><td></td><td>Relais API indépendant compatible OpenAI. Utilisez une clé API personnelle et consultez l’usage ; vérifiez <code>/v1/models</code> et le site pour la disponibilité actuelle. Service non officiel d’OpenAI.</td></tr>
   </tbody>
 </table>
 

--- a/ru.md
+++ b/ru.md
@@ -161,7 +161,7 @@
     <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>Заявка на бесплатный API-ключ, OpenAI-совместимые конечные точки с высокой скоростью</td></tr>
     <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>1M бесплатных токенов ежедневно и скорость вывода до 450+ ток/с</td></tr>
     <tr><td>60</td><td>Infini GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>DeepSeek R1/V3 full-power токены бесплатны, без инвайт-кодов</td></tr>
-    <tr><td>61</td><td>AI Router</td><td><a href="https://ai-router.dev/ru" target="_blank">https://ai-router.dev/ru</a></td><td>🔓🎁😆💰</td><td>OpenAI-совместимый API-релей; 5U после регистрации, до 15U разблокируется 1:1 при соответствующих пополнениях; ежедневный check-in: $1 + 2% расходов за вчера. Не официальный сервис OpenAI.</td></tr>
+    <tr><td>61</td><td>AI Router</td><td><a href="https://ai-router.dev/ru" target="_blank">https://ai-router.dev/ru</a></td><td></td><td>Независимый API-релей, совместимый с OpenAI. Используйте персональный API-ключ и отслеживайте расход; актуальную доступность проверяйте через <code>/v1/models</code> и сайт. Неофициальный сервис OpenAI.</td></tr>
   </tbody>
 </table>
 

--- a/ru.md
+++ b/ru.md
@@ -161,6 +161,7 @@
     <tr><td>58</td><td>Groq Cloud</td><td><a href="https://groq.com/groqcloud" target="_blank">https://groq.com/groqcloud</a></td><td>🔓🎉🌎</td><td>Заявка на бесплатный API-ключ, OpenAI-совместимые конечные точки с высокой скоростью</td></tr>
     <tr><td>59</td><td>Cerebras Inference</td><td><a href="https://inference.cerebras.ai" target="_blank">https://inference.cerebras.ai</a></td><td>🔓🎉🌎🚀</td><td>1M бесплатных токенов ежедневно и скорость вывода до 450+ ток/с</td></tr>
     <tr><td>60</td><td>Infini GenStudio</td><td><a href="https://cloud.infini-ai.com/genstudio" target="_blank">https://cloud.infini-ai.com/genstudio</a></td><td>🆓🎉</td><td>DeepSeek R1/V3 full-power токены бесплатны, без инвайт-кодов</td></tr>
+    <tr><td>61</td><td>AI Router</td><td><a href="https://ai-router.dev/ru" target="_blank">https://ai-router.dev/ru</a></td><td>🔓🎁😆💰</td><td>OpenAI-совместимый API-релей; 5U после регистрации, до 15U разблокируется 1:1 при соответствующих пополнениях; ежедневный check-in: $1 + 2% расходов за вчера. Не официальный сервис OpenAI.</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Summary

Adds AI Router to the Chinese, English, Russian, and French provider tables with matching localized landing pages:

- Chinese: `https://ai-router.dev/cn`
- English: `https://ai-router.dev`
- Russian: `https://ai-router.dev/ru`
- French: `https://ai-router.dev/fr`

The entry uses only the repository's existing factual tags:
- `🔓`: 5U is available after signup
- `🎁`: up to 15U is unlocked 1:1 with eligible top-ups
- `😆`: daily check-in rewards $1 plus 2% of the previous day's spend
- `💰`: paid packages/top-ups are also available

It explicitly states that AI Router is not an official OpenAI service and makes no unverified claim about models, pricing, nodes, or uptime.

Operator disclosure: self-submission by AI Router; no referral link.